### PR TITLE
Ref. vng-Realisatie/gemma-zaken#130 -- mogelijke foutantwoorden in OAS

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,7 +5,7 @@ python-dateutil
 pytz
 raven
 
-Django>=1.11,<2
+Django>1.11,<2.1
 django-axes
 django-choices
 django-hijack
@@ -20,7 +20,7 @@ django-filter
 djangorestframework-camel-case
 djangorestframework-filters
 drf-yasg==1.9.1
-zds-schema
+zds-schema==0.0.33
 
 drf-flex-fields
 django-oauth-toolkit

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ django-oauth-toolkit==1.0.0
 django-ordered-model==1.4.3  # via django-admin-index
 django-redis==4.8.0
 django-rosetta==0.7.14
-django==1.11.9
+django==2.0.8
 djangorestframework-camel-case==0.2.0
 djangorestframework-filters==0.10.2
 djangorestframework==3.7.7
@@ -52,10 +52,10 @@ pyyaml==3.12              # via zds-schema
 raven==6.4.0
 redis==2.10.6             # via django-redis
 requests-oauthlib==0.8.0
-requests==2.18.4          # via coreapi, django-oauth-toolkit, django-rosetta, microsofttranslator, requests-oauthlib
+requests==2.18.4          # via coreapi, django-oauth-toolkit, django-rosetta, microsofttranslator, requests-oauthlib, zds-schema
 ruamel.yaml==0.15.54      # via drf-yasg
 six==1.11.0               # via django-compat, django-rosetta, drf-yasg, isodate, microsofttranslator, pip-tools, python-dateutil
 unidecode==1.0.22         # via zds-schema
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.22             # via requests
-zds-schema==0.0.26
+zds-schema==0.0.33

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -29,7 +29,7 @@ django-ordered-model==1.4.3
 django-redis==4.8.0
 django-rosetta==0.7.14
 django-webtest==1.9.3
-django==1.11.9
+django==2.0.8
 djangorestframework-camel-case==0.2.0
 djangorestframework-filters==0.10.2
 djangorestframework==3.7.7
@@ -82,4 +82,4 @@ waitress==1.1.0           # via webtest
 webob==1.8.2              # via webtest
 webtest==2.0.30
 wrapt==1.10.11            # via astroid
-zds-schema==0.0.26
+zds-schema==0.0.33

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -75,6 +75,54 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Catalogus'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - catalogussen
     parameters: []
@@ -91,6 +139,54 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/InformatieObjectType'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - catalogussen
     parameters:
@@ -114,6 +210,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InformatieObjectType'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - catalogussen
     parameters:
@@ -144,6 +294,54 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ZaakType'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - catalogussen
     parameters:
@@ -167,6 +365,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ZaakType'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - catalogussen
     parameters:
@@ -197,6 +449,54 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Eigenschap'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - catalogussen
     parameters:
@@ -229,6 +529,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Eigenschap'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - catalogussen
     parameters:
@@ -282,6 +636,54 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/RolType'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - catalogussen
     parameters:
@@ -312,6 +714,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RolType'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - catalogussen
     parameters:
@@ -348,6 +804,54 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/StatusType'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - catalogussen
     parameters:
@@ -376,6 +880,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StatusType'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - catalogussen
     parameters:
@@ -415,6 +973,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Catalogus'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - catalogussen
     parameters:
@@ -500,6 +1112,45 @@ components:
             format: uri
           readOnly: true
           uniqueItems: true
+    Fout:
+      required:
+        - code
+        - title
+        - status
+        - detail
+        - instance
+      type: object
+      properties:
+        type:
+          title: Type
+          description: 'URI referentie naar het type fout, bedoeld voor developers'
+          type: string
+        code:
+          title: Code
+          description: Systeemcode die het type fout aangeeft
+          type: string
+          minLength: 1
+        title:
+          title: Title
+          description: Generieke titel voor het type fout
+          type: string
+          minLength: 1
+        status:
+          title: Status
+          description: De HTTP status code
+          type: integer
+        detail:
+          title: Detail
+          description: 'Extra informatie bij de fout, indien beschikbaar'
+          type: string
+          minLength: 1
+        instance:
+          title: Instance
+          description: >-
+            URI met referentie naar dit specifiek voorkomen van de fout. Deze
+            kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
+          type: string
+          minLength: 1
     InformatieObjectType:
       required:
         - omschrijving

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -58,6 +58,54 @@
                                 "$ref": "#/definitions/Catalogus"
                             }
                         }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
                     }
                 },
                 "tags": [
@@ -79,6 +127,54 @@
                             "items": {
                                 "$ref": "#/definitions/InformatieObjectType"
                             }
+                        }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
                         }
                     }
                 },
@@ -107,6 +203,60 @@
                         "description": "",
                         "schema": {
                             "$ref": "#/definitions/InformatieObjectType"
+                        }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
                         }
                     }
                 },
@@ -147,6 +297,54 @@
                                 "$ref": "#/definitions/ZaakType"
                             }
                         }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
                     }
                 },
                 "tags": [
@@ -174,6 +372,60 @@
                         "description": "",
                         "schema": {
                             "$ref": "#/definitions/ZaakType"
+                        }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
                         }
                     }
                 },
@@ -214,6 +466,54 @@
                                 "$ref": "#/definitions/Eigenschap"
                             }
                         }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
                     }
                 },
                 "tags": [
@@ -249,6 +549,60 @@
                         "description": "",
                         "schema": {
                             "$ref": "#/definitions/Eigenschap"
+                        }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
                         }
                     }
                 },
@@ -315,6 +669,54 @@
                                 "$ref": "#/definitions/RolType"
                             }
                         }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
                     }
                 },
                 "tags": [
@@ -350,6 +752,60 @@
                         "description": "",
                         "schema": {
                             "$ref": "#/definitions/RolType"
+                        }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
                         }
                     }
                 },
@@ -397,6 +853,54 @@
                                 "$ref": "#/definitions/StatusType"
                             }
                         }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
                     }
                 },
                 "tags": [
@@ -432,6 +936,60 @@
                         "description": "",
                         "schema": {
                             "$ref": "#/definitions/StatusType"
+                        }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
                         }
                     }
                 },
@@ -476,6 +1034,60 @@
                         "description": "",
                         "schema": {
                             "$ref": "#/definitions/Catalogus"
+                        }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
                         }
                     }
                 },
@@ -552,6 +1164,52 @@
                     },
                     "readOnly": true,
                     "uniqueItems": true
+                }
+            }
+        },
+        "Fout": {
+            "required": [
+                "code",
+                "title",
+                "status",
+                "detail",
+                "instance"
+            ],
+            "type": "object",
+            "properties": {
+                "type": {
+                    "title": "Type",
+                    "description": "URI referentie naar het type fout, bedoeld voor developers",
+                    "type": "string"
+                },
+                "code": {
+                    "title": "Code",
+                    "description": "Systeemcode die het type fout aangeeft",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "title": {
+                    "title": "Title",
+                    "description": "Generieke titel voor het type fout",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "status": {
+                    "title": "Status",
+                    "description": "De HTTP status code",
+                    "type": "integer"
+                },
+                "detail": {
+                    "title": "Detail",
+                    "description": "Extra informatie bij de fout, indien beschikbaar",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "instance": {
+                    "title": "Instance",
+                    "description": "URI met referentie naar dit specifiek voorkomen van de fout. Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.",
+                    "type": "string",
+                    "minLength": 1
                 }
             }
         },

--- a/src/ztc/api/oauth2_urls.py
+++ b/src/ztc/api/oauth2_urls.py
@@ -1,11 +1,13 @@
-from django.conf.urls import url
+from django.urls import path
 
 from oauth2_provider import views as oauth2_views
 
 oauth2_endpoint_views = [
-    url(r'^authorize/$', oauth2_views.AuthorizationView.as_view(), name="authorize"),
-    url(r'^token/$', oauth2_views.TokenView.as_view(), name="token"),
-    url(r'^revoke-token/$', oauth2_views.RevokeTokenView.as_view(), name="revoke-token"),
+    path('authorize/', oauth2_views.AuthorizationView.as_view(), name="authorize"),
+    path('token/', oauth2_views.TokenView.as_view(), name="token"),
+    path('revoke-token/', oauth2_views.RevokeTokenView.as_view(), name="revoke-token"),
 ]
+
+app_name = 'oauth2_provider'
 
 urlpatterns = oauth2_endpoint_views

--- a/src/ztc/api/tests/test_api_strategy.py
+++ b/src/ztc/api/tests/test_api_strategy.py
@@ -10,9 +10,10 @@ from django.utils.translation import ugettext_lazy as _
 
 from oauth2_provider.models import AccessToken, Application
 from rest_framework.settings import api_settings
-from rest_framework.test import APILiveServerTestCase
+from rest_framework.test import APILiveServerTestCase, APIRequestFactory
 from zds_schema.tests import get_operation_url
 
+from . import views
 from ...datamodel.models import Catalogus
 from ...datamodel.tests.factories import (
     BesluitTypeFactory, InformatieObjectTypeFactory, ZaakTypeFactory
@@ -714,3 +715,166 @@ class ErrorHandlingTests(APITestCase):
             'detail': _('Not found.'),
             'instance': non_existing_detail_url
         })
+
+
+class DSOApi50Tests(APITestCase):
+    """
+    Test the error handling responses (API-50).
+    """
+    maxDiff = None
+    factory = APIRequestFactory()
+
+    def assertErrorResponse(self, view, expected_data: dict):
+        _view = view.as_view()
+        # method doesn't matter since we're using `dispatch`
+        request = self.factory.get('/some/irrelevant/url')
+
+        response = _view(request)
+
+        expected_status = expected_data['status']
+        self.assertEqual(response.status_code, expected_status)
+
+        # can't verify UUID...
+        self.assertTrue(response.data['instance'].startswith('urn:uuid:'))
+        del response.data['instance']
+
+        exc_class = view.exception.__class__.__name__
+        expected_data['type'] = f'URI: http://testserver/ref/fouten/{exc_class}/'
+        self.assertEqual(response.data, expected_data)
+
+    def test_400_error(self):
+        self.assertErrorResponse(
+            views.ValidationErrorView,
+            {
+                'code': 'invalid',
+                'title': 'Invalid input.',
+                'status': 400,
+                'detail': '',
+                'invalid-params': [{
+                    'name': 'foo',
+                    'code': 'validation-error',
+                    'reason': 'Invalid data.',
+                }]
+            }
+        )
+
+    def test_401_error(self):
+        self.assertErrorResponse(
+            views.NotAuthenticatedView,
+            {
+                'code': 'not_authenticated',
+                'title': "Authenticatiegegevens zijn niet opgegeven.",
+                'status': 401,
+                'detail': "Authenticatiegegevens zijn niet opgegeven.",
+            }
+        )
+
+    def test_403_error(self):
+        self.assertErrorResponse(
+            views.PermissionDeniedView,
+            {
+                'code': 'permission_denied',
+                'title': 'Je hebt geen toestemming om deze actie uit te voeren.',
+                'status': 403,
+                'detail': 'This action is not allowed',
+            }
+        )
+
+    def test_404_error(self):
+        self.assertErrorResponse(
+            views.NotFoundView,
+            {
+                'code': 'not_found',
+                'title': "Niet gevonden.",
+                'status': 404,
+                'detail': "Some detail message",
+            }
+        )
+
+    def test_405_error(self):
+        self.assertErrorResponse(
+            views.MethodNotAllowedView,
+            {
+                'code': 'method_not_allowed',
+                'title': 'Methode "{method}" niet toegestaan.',
+                'status': 405,
+                'detail': 'Methode "GET" niet toegestaan.',
+            }
+        )
+
+    def test_406_error(self):
+        self.assertErrorResponse(
+            views.NotAcceptableView,
+            {
+                'code': 'not_acceptable',
+                'title': 'Kan niet voldoen aan de opgegeven Accept header.',
+                'status': 406,
+                'detail': 'Content negotation failed',
+            }
+        )
+
+    def test_409_error(self):
+        self.assertErrorResponse(
+            views.ConflictView,
+            {
+                'code': 'conflict',
+                'title': 'A conflict occurred',
+                'status': 409,
+                'detail': 'The resource was updated, please retrieve it again',
+            }
+        )
+
+    def test_410_error(self):
+        self.assertErrorResponse(
+            views.GoneView,
+            {
+                'code': 'gone',
+                'title': 'The resource is gone',
+                'status': 410,
+                'detail': 'The resource was destroyed',
+            }
+        )
+
+    def test_412_error(self):
+        self.assertErrorResponse(
+            views.PreconditionFailed,
+            {
+                'code': 'precondition_failed',
+                'title': 'Precondition failed',
+                'status': 412,
+                'detail': "Something about CRS",
+            }
+        )
+
+    def test_415_error(self):
+        self.assertErrorResponse(
+            views.UnsupportedMediaTypeView,
+            {
+                'code': 'unsupported_media_type',
+                'title': 'Ongeldige media type "{media_type}" in aanvraag.',
+                'status': 415,
+                'detail': 'This media type is not supported',
+            }
+        )
+
+    def test_429_error(self):
+        self.assertErrorResponse(
+            views.ThrottledView,
+            {
+                'code': 'throttled',
+                'title': 'Aanvraag was verstikt.',
+                'status': 429,
+                'detail': "Too many requests",
+            }
+        )
+
+    def test_500_error(self):
+        self.assertErrorResponse(
+            views.InternalServerErrorView,
+            {
+                'code': 'error',
+                'title': 'Er is een serverfout opgetreden.',
+                'status': 500,
+                'detail': "Everything broke",
+            }
+        )

--- a/src/ztc/api/tests/views.py
+++ b/src/ztc/api/tests/views.py
@@ -1,0 +1,67 @@
+"""
+Dummy views to use in unit tests.
+"""
+
+from rest_framework import authentication, exceptions, permissions
+from rest_framework.views import APIView
+from zds_schema.exceptions import Conflict, Gone, PreconditionFailed
+
+
+class BaseErrorView(APIView):
+    authentication_classes = ()
+    permission_classes = ()
+
+    exception = None
+
+    def get(self, request, *args, **kwargs):
+        raise self.exception
+
+
+class ValidationErrorView(BaseErrorView):
+    exception = exceptions.ValidationError({'foo': ["Invalid data."]}, code='validation-error')
+
+
+class NotFoundView(BaseErrorView):
+    exception = exceptions.NotFound("Some detail message")
+
+
+class NotAuthenticatedView(BaseErrorView):
+    authentication_classes = (authentication.BasicAuthentication,)
+    permission_classes = (permissions.IsAuthenticated,)
+    exception = exceptions.NotAuthenticated()
+
+
+class PermissionDeniedView(BaseErrorView):
+    exception = exceptions.PermissionDenied("This action is not allowed")
+
+
+class MethodNotAllowedView(BaseErrorView):
+    exception = exceptions.MethodNotAllowed("GET")
+
+
+class NotAcceptableView(BaseErrorView):
+    exception = exceptions.NotAcceptable("Content negotation failed")
+
+
+class ConflictView(BaseErrorView):
+    exception = Conflict("The resource was updated, please retrieve it again")
+
+
+class GoneView(BaseErrorView):
+    exception = Gone("The resource was destroyed")
+
+
+class PreconditionFailed(BaseErrorView):
+    exception = PreconditionFailed("Something about CRS")
+
+
+class UnsupportedMediaTypeView(BaseErrorView):
+    exception = exceptions.UnsupportedMediaType('application/xml', detail="This media type is not supported")
+
+
+class ThrottledView(BaseErrorView):
+    exception = exceptions.Throttled(detail="Too many requests")
+
+
+class InternalServerErrorView(BaseErrorView):
+    exception = exceptions.APIException("Everything broke")

--- a/src/ztc/conf/api.py
+++ b/src/ztc/conf/api.py
@@ -1,10 +1,7 @@
-REST_FRAMEWORK = {
-    'DEFAULT_RENDERER_CLASSES': (
-        'djangorestframework_camel_case.render.CamelCaseJSONRenderer',
-    ),
-    'DEFAULT_PARSER_CLASSES': (
-        'djangorestframework_camel_case.parser.CamelCaseJSONParser',
-    ),
+from zds_schema.conf.api import BASE_REST_FRAMEWORK, BASE_SWAGGER_SETTINGS
+
+REST_FRAMEWORK = BASE_REST_FRAMEWORK.copy()
+REST_FRAMEWORK.update({
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
         # 'rest_framework.authentication.SessionAuthentication',
@@ -15,38 +12,15 @@ REST_FRAMEWORK = {
         # 'rest_framework.permissions.IsAuthenticated',
         # 'rest_framework.permissions.AllowAny',
     ),
-    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.URLPathVersioning',
-    #
-    # # Generic view behavior
     'DEFAULT_PAGINATION_CLASS': 'ztc.api.utils.pagination.HALPagination',
-    'DEFAULT_FILTER_BACKENDS': (
-        'zds_schema.filters.Backend',
-        # 'rest_framework.filters.SearchFilter',
-        # 'rest_framework.filters.OrderingFilter',
-    ),
-    #
-    # # Filtering
+    # Filtering
     'SEARCH_PARAM': 'zoek',  # 'search',
     'ORDERING_PARAM': 'sorteer',  # 'ordering',
-    #
-    # Versioning
-    'DEFAULT_VERSION': '1',
-    'ALLOWED_VERSIONS': ('1', ),
-    'VERSION_PARAM': 'version',
-    #
-    # # Exception handling
-    'EXCEPTION_HANDLER': 'ztc.api.utils.exceptions.exception_handler',
-    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
-}
+})
 
-REST_FRAMEWORK_EXT = {
-    'PAGE_PARAM': 'pagina',
-    'EXPAND_PARAM': 'expand',
-    'EXPAND_ALL_VALUE': 'true',
-    'FIELDS_PARAM': 'fields',
-}
 
-SWAGGER_SETTINGS = {
+SWAGGER_SETTINGS = BASE_SWAGGER_SETTINGS.copy()
+SWAGGER_SETTINGS.update({
     'SECURITY_DEFINITIONS': {
         'OAuth2': {
             'type': 'oauth2',
@@ -63,21 +37,14 @@ SWAGGER_SETTINGS = {
             'in': 'header'
         },
     },
-    'DEFAULT_AUTO_SCHEMA_CLASS': 'zds_schema.schema.AutoSchema',
     'DEFAULT_INFO': 'ztc.api.schema.info',
-    'DEFAULT_FIELD_INSPECTORS': (
-        'drf_yasg.inspectors.CamelCaseJSONFilter',
-        'drf_yasg.inspectors.RecursiveFieldInspector',
-        'drf_yasg.inspectors.ReferencingSerializerInspector',
-        'drf_yasg.inspectors.ChoiceFieldInspector',
-        'drf_yasg.inspectors.FileFieldInspector',
-        'drf_yasg.inspectors.DictFieldInspector',
-        'drf_yasg.inspectors.HiddenFieldInspector',
-        'drf_yasg.inspectors.RelatedFieldInspector',
-        'drf_yasg.inspectors.SimpleFieldInspector',
-        'drf_yasg.inspectors.StringDefaultFieldInspector',
-    ),
-    'DEFAULT_FILTER_INSPECTORS': (
-        'zds_schema.inspectors.query.FilterInspector',
-    )
+    # no geo things here
+    'DEFAULT_FIELD_INSPECTORS': BASE_SWAGGER_SETTINGS['DEFAULT_FIELD_INSPECTORS'][1:]
+})
+
+REST_FRAMEWORK_EXT = {
+    'PAGE_PARAM': 'pagina',
+    'EXPAND_PARAM': 'expand',
+    'EXPAND_ALL_VALUE': 'true',
+    'FIELDS_PARAM': 'fields',
 }

--- a/src/ztc/datamodel/models/besluittype.py
+++ b/src/ztc/datamodel/models/besluittype.py
@@ -53,7 +53,9 @@ class BesluitType(GeldigheidMixin, models.Model):
 
     maakt_deel_uit_van = models.ForeignKey(
         'datamodel.Catalogus', verbose_name=_('catalogus'),
-        help_text=_('De CATALOGUS waartoe dit BESLUITTYPE behoort.'))
+        help_text=_('De CATALOGUS waartoe dit BESLUITTYPE behoort.'),
+        on_delete=models.CASCADE
+    )
     wordt_vastgelegd_in = models.ManyToManyField(
         'datamodel.InformatieObjectType', verbose_name=_('informatieobjecttype'), blank=True,
         help_text=_('Het INFORMATIEOBJECTTYPE van informatieobjecten waarin besluiten van dit BESLUITTYPE worden vastgelegd.'))

--- a/src/ztc/datamodel/models/eigenschap.py
+++ b/src/ztc/datamodel/models/eigenschap.py
@@ -174,11 +174,12 @@ class Eigenschap(GeldigheidMixin, models.Model):
         'De beschrijving van de betekenis van deze EIGENSCHAP'))
     specificatie_van_eigenschap = models.ForeignKey(
         'datamodel.EigenschapSpecificatie', verbose_name=_('specificatie van eigenschap'),
-        blank=True, null=True, help_text=_('Attribuutkenmerken van de eigenschap')
+        blank=True, null=True, help_text=_('Attribuutkenmerken van de eigenschap'),
+        on_delete=models.CASCADE
     )
     referentie_naar_eigenschap = models.ForeignKey(
         'datamodel.EigenschapReferentie', verbose_name=_('referentie naar eigenschap'),
-        blank=True, null=True,
+        blank=True, null=True, on_delete=models.CASCADE,
         help_text=_('Verwijzing naar de standaard waarin de eigenschap is gespecificeerd')
     )
     toelichting = models.CharField(
@@ -189,13 +190,15 @@ class Eigenschap(GeldigheidMixin, models.Model):
     # shouldn't this be a M2M?
     status_type = models.ForeignKey(
         'datamodel.StatusType', verbose_name=_('status type'),
-        blank=True, null=True,
+        blank=True, null=True, on_delete=models.CASCADE,
         related_name='heeft_verplichte_eigenschap', help_text=_(
             'Status type moet (onder andere) deze EIGENSCHAP hebben, voordat een '
             'STATUS van het STATUSTYPE kan worden gezet.')
     )
     is_van = models.ForeignKey('datamodel.ZaakType', verbose_name=_('is van'), help_text=_(
-        'Het ZAAKTYPE van de ZAAKen waarvoor deze EIGENSCHAP van belang is.'))
+        'Het ZAAKTYPE van de ZAAKen waarvoor deze EIGENSCHAP van belang is.'),
+        on_delete=models.CASCADE
+    )
 
     class Meta:
         mnemonic = 'EIG'

--- a/src/ztc/datamodel/models/informatieobjecttype.py
+++ b/src/ztc/datamodel/models/informatieobjecttype.py
@@ -70,7 +70,8 @@ class InformatieObjectType(GeldigheidMixin, models.Model):
         help_text=_('Omschrijving van de aard van informatieobjecten van dit INFORMATIEOBJECTTYPE.'))
     informatieobjecttype_omschrijving_generiek = models.ForeignKey(
         'datamodel.InformatieObjectTypeOmschrijvingGeneriek', verbose_name=_('omschrijving generiek'),
-        blank=True, null=True, help_text=_('Algemeen gehanteerde omschrijving van het INFORMATIEOBJECTTYPE.'))
+        blank=True, null=True, on_delete=models.CASCADE,
+        help_text=_('Algemeen gehanteerde omschrijving van het INFORMATIEOBJECTTYPE.'))
     informatieobjectcategorie = models.CharField(
         _('categorie'), max_length=80,
         help_text=_('Typering van de aard van informatieobjecten van dit INFORMATIEOBJECTTYPE.'))
@@ -92,8 +93,10 @@ class InformatieObjectType(GeldigheidMixin, models.Model):
         _('toelichting'), max_length=1000, blank=True, null=True,
         help_text=_('Een eventuele toelichting op dit INFORMATIEOBJECTTYPE.'))
 
-    maakt_deel_uit_van = models.ForeignKey('datamodel.Catalogus', verbose_name=_('maakt deel uit van'),
-                                           help_text=('De CATALOGUS waartoe dit INFORMATIEOBJECTTYPE behoort.'))
+    maakt_deel_uit_van = models.ForeignKey(
+        'datamodel.Catalogus', verbose_name=_('maakt deel uit van'),
+        on_delete=models.CASCADE, help_text=('De CATALOGUS waartoe dit INFORMATIEOBJECTTYPE behoort.')
+    )
 
     zaaktypes = models.ManyToManyField(
         'datamodel.ZaakType', verbose_name=_('zaaktypes'), related_name='heeft_relevant_informatieobjecttype',
@@ -118,7 +121,6 @@ class InformatieObjectType(GeldigheidMixin, models.Model):
             'informatieobjecttypetrefwoord',
             'toelichting',
         )
-
 
     def clean(self):
         """

--- a/src/ztc/datamodel/models/relatieklassen.py
+++ b/src/ztc/datamodel/models/relatieklassen.py
@@ -13,9 +13,11 @@ class ZaakInformatieobjectType(models.Model):
 
     Kenmerken van de relatie ZAAKTYPE heeft relevante INFORMATIEOBJECTTYPEn.
     """
-    zaaktype = models.ForeignKey('datamodel.Zaaktype', verbose_name=_('zaaktype'))
-    informatie_object_type = models.ForeignKey('datamodel.InformatieObjectType',
-                                               verbose_name=_('informatie object type'))
+    zaaktype = models.ForeignKey('datamodel.Zaaktype', verbose_name=_('zaaktype'), on_delete=models.CASCADE)
+    informatie_object_type = models.ForeignKey(
+        'datamodel.InformatieObjectType', on_delete=models.CASCADE,
+        verbose_name=_('informatie object type')
+    )
 
     volgnummer = models.PositiveSmallIntegerField(
         _('volgnummer'), validators=[MinValueValidator(1), MaxValueValidator(999)], help_text=_(
@@ -27,6 +29,7 @@ class ZaakInformatieobjectType(models.Model):
     # this is the relation that is described on StatusType in the specification
     status_type = models.ForeignKey(
         'datamodel.StatusType', verbose_name=_('status type'), blank=True, null=True,
+        on_delete=models.CASCADE,
         related_name='heeft_verplichte_zit', help_text=_(
             'De informatieobjecten van de INFORMATIEOBJECTTYPEn van het aan het STATUSTYPE gerelateerde ZAAKTYPE '
             'waarvoor geldt dat deze verplicht aanwezig moeten zijn bij een zaak van het gerelateerde ZAAKTYPE '
@@ -61,9 +64,14 @@ class ZaakInformatieobjectTypeArchiefregime(models.Model):
     INFORMATIEOBJECTTYPE bij zaken van een ZAAKTYPE op grond van
     resultaten van een RESULTAATTYPE bij dat ZAAKTYPE
     """
-    zaak_informatieobject_type = models.ForeignKey('datamodel.ZaakInformatieobjectType',
-                                                   verbose_name=_('zaakinformatie object type'))
-    resultaattype = models.ForeignKey('datamodel.ResultaatType', verbose_name=_('resultaattype'))
+    zaak_informatieobject_type = models.ForeignKey(
+        'datamodel.ZaakInformatieobjectType', on_delete=models.CASCADE,
+        verbose_name=_('zaakinformatie object type')
+    )
+    resultaattype = models.ForeignKey(
+        'datamodel.ResultaatType', verbose_name=_('resultaattype'),
+        on_delete=models.CASCADE
+    )
 
     # TODO [KING]:  waardenverzameling 'de aanduidingen van de passages cq. klassen in de gehanteerde selectielijst.'
     selectielijstklasse = models.CharField(
@@ -111,9 +119,9 @@ class ZaakTypenRelatie(models.Model):
     Kenmerken van de relatie ZAAKTYPE heeft gerelateerde ZAAKTYPE.
     """
     zaaktype_van = models.ForeignKey('datamodel.ZaakType', verbose_name=_('zaaktype van'),
-                                     related_name='zaaktypenrelatie_van')
+                                     related_name='zaaktypenrelatie_van', on_delete=models.CASCADE)
     zaaktype_naar = models.ForeignKey('datamodel.ZaakType', verbose_name=_('zaaktype naar'),
-                                      related_name='zaaktypenrelatie_naar')
+                                      related_name='zaaktypenrelatie_naar', on_delete=models.CASCADE)
 
     aard_relatie = models.CharField(_('aard relatie'), max_length=15, choices=AardRelatieChoices.choices, help_text=_(
         'Omschrijving van de aard van de relatie van zaken van het ZAAKTYPE tot zaken van het andere ZAAKTYPE'))

--- a/src/ztc/datamodel/models/resultaattype.py
+++ b/src/ztc/datamodel/models/resultaattype.py
@@ -76,11 +76,16 @@ class ResultaatType(GeldigheidMixin, models.Model):
             'ZAAKTYPE voordat een resultaat van dit RESULTAATTYPE kan worden gezet.')
     )
     heeft_voor_brondatum_archiefprocedure_relevante = models.ForeignKey(
-        'datamodel.Eigenschap', verbose_name=_('heeft voor brondatum archiefprocedure relevante'), blank=True, null=True,
+        'datamodel.Eigenschap',
+        verbose_name=_('heeft voor brondatum archiefprocedure relevante'),
+        blank=True, null=True, on_delete=models.CASCADE,
         help_text=_('De EIGENSCHAP die bepalend is voor het moment waarop de Archiefactietermijn start voor een ZAAK '
                     'met een resultaat van dit RESULTAATTYPE.'))
-    is_relevant_voor = models.ForeignKey('datamodel.ZaakType', verbose_name=_('is relevant voor'), help_text=_(
-        'Het ZAAKTYPE van ZAAKen waarin resultaten van dit RESULTAATTYPE bereikt kunnen worden.'))
+    is_relevant_voor = models.ForeignKey(
+        'datamodel.ZaakType', verbose_name=_('is relevant voor'),
+        on_delete=models.CASCADE, help_text=_(
+            'Het ZAAKTYPE van ZAAKen waarin resultaten van dit RESULTAATTYPE bereikt kunnen worden.')
+    )
 
     class Meta:
         mnemonic = 'RST'

--- a/src/ztc/datamodel/models/roltype.py
+++ b/src/ztc/datamodel/models/roltype.py
@@ -47,7 +47,7 @@ class RolType(GeldigheidMixin, models.Model):
         default=list
     )
     zaaktype = models.ForeignKey(
-        'datamodel.ZaakType', verbose_name=_('is van'),
+        'datamodel.ZaakType', verbose_name=_('is van'), on_delete=models.CASCADE,
         help_text=_('De ROLTYPEn waarin BETROKKENEn een ROL kunnen uitoefenen in ZAAKen van dit ZAAKTYPE.')
     )
 
@@ -77,7 +77,7 @@ class RolType(GeldigheidMixin, models.Model):
 
 class MogelijkeBetrokkene(models.Model):
     uuid = models.UUIDField(default=uuid.uuid4)
-    roltype = models.ForeignKey(RolType)
+    roltype = models.ForeignKey(RolType, on_delete=models.CASCADE)
 
     betrokkene = models.URLField(help_text="Een betrokkene die kan gerelateerd worden aan een zaak")
     betrokkene_type = models.CharField(max_length=100, choices=RolTypes.choices)

--- a/src/ztc/datamodel/models/statustype.py
+++ b/src/ztc/datamodel/models/statustype.py
@@ -48,7 +48,7 @@ class StatusType(GeldigheidMixin, models.Model):
 
     # relations
     is_van = models.ForeignKey(
-        'ZaakType', verbose_name=_('is van'), related_name='statustypen',
+        'ZaakType', verbose_name=_('is van'), related_name='statustypen', on_delete=models.CASCADE,
         help_text=_('Het ZAAKTYPE van ZAAKen waarin STATUSsen van dit STATUSTYPE bereikt kunnen worden.')
     )
 

--- a/src/ztc/datamodel/models/zaken.py
+++ b/src/ztc/datamodel/models/zaken.py
@@ -38,12 +38,16 @@ class ZaakObjectType(GeldigheidMixin, models.Model):
 
     status_type = models.ForeignKey(
         'datamodel.StatusType', verbose_name=_('status type'), blank=True, null=True,
+        on_delete=models.CASCADE,
         related_name='heeft_verplichte_zaakobjecttype', help_text=_(
             'TODO: dit is de related helptext: De ZAAKOBJECTTYPEn die verplicht gerelateerd moeten zijn aan ZAAKen van '
             'het ZAAKTYPE voordat een STATUS van dit STATUSTYPE kan worden gezet'))
 
-    is_relevant_voor = models.ForeignKey('datamodel.ZaakType', verbose_name=_('is_relevant_voor'), help_text=_(
-        'Zaken van het ZAAKTYPE waarvoor objecten van dit ZAAKOBJECTTYPE relevant zijn.'))
+    is_relevant_voor = models.ForeignKey(
+        'datamodel.ZaakType', verbose_name=_('is_relevant_voor'), help_text=_(
+            'Zaken van het ZAAKTYPE waarvoor objecten van dit ZAAKOBJECTTYPE relevant zijn.'),
+        on_delete=models.CASCADE
+    )
 
     class Meta:
         mnemonic = 'ZOT'
@@ -373,12 +377,19 @@ class ZaakType(GeldigheidMixin, models.Model):
         'datamodel.Formulier', verbose_name=_('formulier'), blank=True,
         help_text=_('Formulier Het formulier dat ZAAKen van dit ZAAKTYPE initieert.')
     )
-    referentieproces = models.ForeignKey('datamodel.ReferentieProces', verbose_name=_('referentieproces'), help_text=_(
-        'Verwijzing naar een gelijknamig groepattribuutsoort.'))
-    broncatalogus = models.ForeignKey('datamodel.BronCatalogus', verbose_name=_('broncatalogus'), blank=True, null=True,
-                                      help_text=_('De CATALOGUS waaraan het ZAAKTYPE is ontleend.'))
+    referentieproces = models.ForeignKey(
+        'datamodel.ReferentieProces', verbose_name=_('referentieproces'),
+        help_text=_('Verwijzing naar een gelijknamig groepattribuutsoort.'),
+        on_delete=models.CASCADE
+    )
+    broncatalogus = models.ForeignKey(
+        'datamodel.BronCatalogus', verbose_name=_('broncatalogus'),
+        blank=True, null=True, on_delete=models.CASCADE,
+        help_text=_('De CATALOGUS waaraan het ZAAKTYPE is ontleend.')
+    )
     bronzaaktype = models.ForeignKey(
-        'datamodel.BronZaakType', verbose_name=('bronzaaktype'), blank=True, null=True,
+        'datamodel.BronZaakType', verbose_name=('bronzaaktype'),
+        blank=True, null=True, on_delete=models.CASCADE,
         help_text=_('Het zaaktype binnen de CATALOGUS waaraan dit ZAAKTYPE is ontleend.')
     )
 
@@ -397,7 +408,7 @@ class ZaakType(GeldigheidMixin, models.Model):
     )
 
     maakt_deel_uit_van = models.ForeignKey(
-        'datamodel.Catalogus', verbose_name=_('maakt deel uit van'),
+        'datamodel.Catalogus', verbose_name=_('maakt deel uit van'), on_delete=models.CASCADE,
         help_text=_('De CATALOGUS waartoe dit ZAAKTYPE behoort.')
     )
 

--- a/src/ztc/sass/components/_all.scss
+++ b/src/ztc/sass/components/_all.scss
@@ -1,3 +1,4 @@
 @import "page-header/all";
 @import "content/all";
 @import "link-block/all";
+@import "error-detail/all";

--- a/src/ztc/sass/components/error-detail/_all.scss
+++ b/src/ztc/sass/components/error-detail/_all.scss
@@ -1,0 +1,2 @@
+@import "error-detail";
+@import "error-detail-properties";

--- a/src/ztc/sass/components/error-detail/_error-detail-properties.scss
+++ b/src/ztc/sass/components/error-detail/_error-detail-properties.scss
@@ -1,0 +1,22 @@
+.error-detail-properties {
+  display: flex;
+  flex-wrap: wrap;
+
+  &__property {
+    width: 20%;
+    min-width: 200px;
+    margin: 0;
+    padding: 10px 0;
+
+    font-weight: 700;
+  }
+
+  &__value {
+    width: 80%;
+    margin: 0;
+    padding: 10px 0;
+
+    font-weight: 700;
+    color: $color-code;
+  }
+}

--- a/src/ztc/sass/components/error-detail/_error-detail.scss
+++ b/src/ztc/sass/components/error-detail/_error-detail.scss
@@ -1,0 +1,13 @@
+@import '../../lib/responsive';
+
+$error-detail-max-width: $breakpoint-laptop-l;
+
+.error-detail {
+  max-width: $error-detail-max-width;
+  margin: 0 auto;
+
+  &__title {
+    color: $color-black;
+    border-bottom: solid 2px $color-vng-blue;
+  }
+}

--- a/src/ztc/sass/lib/_color.scss
+++ b/src/ztc/sass/lib/_color.scss
@@ -2,3 +2,4 @@ $color-white: #FFF;
 $color-black: #041A34;
 
 $color-vng-blue: #009FE3;
+$color-code: #D14;

--- a/src/ztc/templates/zds_schema/error_detail.html
+++ b/src/ztc/templates/zds_schema/error_detail.html
@@ -1,0 +1,23 @@
+{% extends "master.html" %}
+{% load staticfiles %}
+
+
+{% block content %}
+<article class="error-detail">
+
+    <h1 class="error-detail__title"><code>{{ type }}</code> fouttype</h1>
+
+    <dl class="error-detail-properties">
+        <dt class="error-detail-properties__property">HTTP Status code</dt>
+        <dd class="error-detail-properties__value"><code>{{ status_code }}</code></dd>
+
+        <dt class="error-detail-properties__property">Default title</dt>
+        <dd class="error-detail-properties__value"><code>{{ default_detail }}</code></dd>
+
+        <dt class="error-detail-properties__property">Default code</dt>
+        <dd class="error-detail-properties__value"><code>{{ default_code }}</code></dd>
+    </dl>
+
+
+</article>
+{% endblock %}

--- a/src/ztc/urls.py
+++ b/src/ztc/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import path, re_path, include
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
@@ -7,19 +7,20 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.views.generic.base import TemplateView
 
 urlpatterns = [
-    url(r'^admin/password_reset/$', auth_views.password_reset, name='admin_password_reset'),
-    url(r'^admin/password_reset/done/$', auth_views.password_reset_done, name='password_reset_done'),
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>.+)/$',
-        auth_views.password_reset_confirm, name='password_reset_confirm'),
-    url(r'^reset/done/$', auth_views.password_reset_complete, name='password_reset_complete'),
+    path('admin/password_reset/', auth_views.password_reset, name='admin_password_reset'),
+    path('admin/password_reset/done/', auth_views.password_reset_done, name='password_reset_done'),
+    path('admin/', admin.site.urls),
+    re_path(r'^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>.+)/$',
+            auth_views.password_reset_confirm, name='password_reset_confirm'),
+    path('reset/done/', auth_views.password_reset_complete, name='password_reset_complete'),
 
     # API views
-    url(r'^api/', include('ztc.api.urls')),
-    url(r'^oauth2/', include('ztc.api.oauth2_urls', namespace='oauth2_provider')),
+    path('api/', include('ztc.api.urls')),
+    path('oauth2/', include('ztc.api.oauth2_urls')),
 
     # Simply show the master template.
-    url(r'^$', TemplateView.as_view(template_name='index.html')),
+    path('', TemplateView.as_view(template_name='index.html')),
+    path('ref/', include('zds_schema.urls')),
 ]
 
 # NOTE: The staticfiles_urlpatterns also discovers static files (ie. no need to run collectstatic). Both the static
@@ -29,5 +30,5 @@ urlpatterns += staticfiles_urlpatterns() + static(settings.MEDIA_URL, document_r
 if settings.DEBUG and 'debug_toolbar' in settings.INSTALLED_APPS:
     import debug_toolbar
     urlpatterns += [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
+        path('__debug__/', include(debug_toolbar.urls)),
     ]

--- a/src/ztc/urls.py
+++ b/src/ztc/urls.py
@@ -1,9 +1,9 @@
 from django.conf import settings
-from django.urls import path, re_path, include
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.urls import include, path, re_path
 from django.views.generic.base import TemplateView
 
 urlpatterns = [


### PR DESCRIPTION
**Wijzigingen**

* Mogelijke responses (HTTP status code) toegevoegd op alle resources:
    * Afhankelijk van de operation (create/read/update/delete/partial_update) een andere set van status codes
    * Formaat van 'generieke' fouten en validatiefouten in OAS schema opgenomen
    * generiek geimplementeerd in vng-Realisatie/gemma-zaken-common
* DSO API-50 tests 
* Tests update naar nieuwe formaat validatie
* Gestylede HTML pagina's voor de typen foutmeldingen
* Gebruik common settings van `zds_schema.conf.api` (minder duplicatie van code/config)

**Links**

[Browsable API spec](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-zaaktypecatalogus/feature/us-130-error-responses/src/openapi.yaml)

**Checklist**

- [x] API test DSO API-50
- [x] Common status codes getest & geimplementeerd:
    - [x] 400 validation errors
    - [x] 401 Auth creds ontbreken
    - [x] 403 Permission denied
    - [x] 404 NotFound
    - [x] 405 Method not allowed
    - [x] 406 Not Acceptable
    - [x] 409 Conflict
    - [x] 410 Gone
    - [x] 412 Precondition failed
    - [x] 415 Unsupported Media Type
    - [x] ~~422 Unprocessable Entity~~ - zal bij ons concreet een HTTP 400 worden met validatiefouten
    - [x] 429 Too Many Requests
    - [x] 500 Internal Server Error
    - [x] ~~503 Service Unavailable~~ - dit moet op webserver niveau opgelost worden
- [x] Introspectie viewsets & foutberichten komen terecht in `openapi.yaml`
- [x] Documentatie betekenis foutcodes
- [x] Documentatie validaties die toegepast worden (functioneel)