### PR TITLE
Add download of fixture data and instructions on how to use it

### DIFF
--- a/src/ztc/sass/components/content/_content.scss
+++ b/src/ztc/sass/components/content/_content.scss
@@ -1,7 +1,12 @@
 @import '../../lib/typography';
+@import '../../lib/responsive';
 
+$content-max-width: $breakpoint-laptop-l;
 
 .content {
+  max-width: $content-max-width;
+  margin: 0 auto;
+
   h1 { @include h1() }
   h2 { @include h2() }
   h3 { @include h3() }
@@ -20,5 +25,7 @@
   code {
     @include body();
     @include monospace();
+    color: $color-code;
+    font-weight: bold;
   }
 }

--- a/src/ztc/templates/dumpdata.html
+++ b/src/ztc/templates/dumpdata.html
@@ -1,0 +1,51 @@
+{% extends "master.html" %}
+{% load markup_tags %}
+
+{% block content %}
+<div class="content">
+{% filter apply_markup:"markdown" %}
+# Catalogus data downloaden en importeren
+
+Indien je zelf deze referentiecomponent host, dan begin je met een lege
+catalogus. Je kan de gegevens van de gehoste referentieimplementatie echter
+importeren in je eigen versie, wat hier beschreven wordt.
+
+## Toegang krijgen tot de container
+
+### In een Kubernetes omgeving
+
+In een Kubernetes omgeving moet je op zoek gaan naar de Pod die het ZTC runt.
+Vervolgens klik je rechtsboven in de interface op `EXEC` om een interactieve
+console in de container te krijgen.
+
+### Zonder Kubernetes
+
+Zoek via `docker ps` het container ID van de ZTC container.
+
+Open een interactieve console:
+
+```
+docker exec -it <container_id> sh
+```
+
+Waarbij je `<container_id>` vervangt door het container ID wat je eerder vond.
+
+## Downloaden data
+
+Je kan nu in de container de _fixture_ met de gegevens downloaden via:
+
+```
+wget {{ fixture_url }} -O /tmp/fixture.json
+```
+
+## Inladen data
+
+Vervolgens kan je deze gevens inladen met:
+
+```
+python /app/src/manage.py loaddata /tmp/fixture.json
+```
+
+{% endfilter %}
+</div>
+{% endblock content %}

--- a/src/ztc/templates/index.html
+++ b/src/ztc/templates/index.html
@@ -11,5 +11,7 @@
 
     <a href="{% url 'admin:index' %}" class="link-block">admin</a>
 
+    <a href="{% url 'dumpdata' %}" class="link-block">testdata</a>
+
 </article>
 {% endblock %}

--- a/src/ztc/urls.py
+++ b/src/ztc/urls.py
@@ -6,6 +6,8 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path, re_path
 from django.views.generic.base import TemplateView
 
+from .views import DumpDataFixtureView, DumpDataView
+
 urlpatterns = [
     path('admin/password_reset/', auth_views.password_reset, name='admin_password_reset'),
     path('admin/password_reset/done/', auth_views.password_reset_done, name='password_reset_done'),
@@ -19,6 +21,8 @@ urlpatterns = [
 
     # Simply show the master template.
     path('', TemplateView.as_view(template_name='index.html')),
+    path('data/', DumpDataView.as_view(), name='dumpdata'),
+    path('data/fixture/', DumpDataFixtureView.as_view(), name='dumpdata-fixture'),
     path('ref/', include('zds_schema.urls')),
 ]
 

--- a/src/ztc/views.py
+++ b/src/ztc/views.py
@@ -1,0 +1,26 @@
+from django.core.management import call_command
+from django.http import HttpResponse
+from django.urls import reverse
+from django.views import View
+from django.views.generic import TemplateView
+
+
+class DumpDataView(TemplateView):
+    template_name = 'dumpdata.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['fixture_url'] = self.request.build_absolute_uri(reverse('dumpdata-fixture'))
+        return context
+
+
+class DumpDataFixtureView(View):
+    """
+    Offer a dumpdata-download as fixture.
+    """
+
+    def get(self, request):
+        response = HttpResponse(content_type='application/json')
+        response['Content-Disposition'] = 'attachment; filename="fixture.json"'
+        call_command('dumpdata', args=['datamodel'], indent=4, stdout=response)
+        return response


### PR DESCRIPTION
De vraag om de ZTC gegevens in een self-hosted omgeving in te kunnen laden komt vaker voor, nu zit het ingebakken in de referentie-implementatie.