### PR TITLE
Feature/filters for draft

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,4 +63,4 @@ six==1.11.0               # via django-compat, django-markup, django-rosetta, dr
 unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
-vng-api-common==0.55.1
+vng-api-common==0.57.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -84,7 +84,7 @@ text-unidecode==1.2       # via faker
 unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
-vng-api-common==0.55.1
+vng-api-common==0.57.0
 waitress==1.3.0           # via webtest
 webob==1.8.5              # via webtest
 webtest==2.0.33

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -82,7 +82,7 @@ text-unidecode==1.2       # via faker
 unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
-vng-api-common==0.55.1
+vng-api-common==0.57.0
 waitress==1.1.0           # via webtest
 webob==1.8.2              # via webtest
 webtest==2.0.30

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -73,13 +73,13 @@ paths:
           format: uri
       - name: publish
         in: query
-        description: 'filter objects depend on their draft status:
+        description: 'filter objects depending on their draft status:
 
-          * all: show all objects
+          * `all`: show all objects
 
-          * draft: show only draft or draft-related objects
+          * `draft`: show only draft or draft-related objects
 
-          * nondraft: show only non-draft or non-draft-related objects (default)
+          * `nondraft`: show only non-draft or non-draft-related objects (default)
 
           '
         required: false
@@ -1066,13 +1066,13 @@ paths:
           format: uri
       - name: publish
         in: query
-        description: 'filter objects depend on their draft status:
+        description: 'filter objects depending on their draft status:
 
-          * all: show all objects
+          * `all`: show all objects
 
-          * draft: show only draft or draft-related objects
+          * `draft`: show only draft or draft-related objects
 
-          * nondraft: show only non-draft or non-draft-related objects (default)
+          * `nondraft`: show only non-draft or non-draft-related objects (default)
 
           '
         required: false
@@ -1627,13 +1627,13 @@ paths:
           format: uri
       - name: publish
         in: query
-        description: 'filter objects depend on their draft status:
+        description: 'filter objects depending on their draft status:
 
-          * all: show all objects
+          * `all`: show all objects
 
-          * draft: show only draft or draft-related objects
+          * `draft`: show only draft or draft-related objects
 
-          * nondraft: show only non-draft or non-draft-related objects (default)
+          * `nondraft`: show only non-draft or non-draft-related objects (default)
 
           '
         required: false
@@ -2221,13 +2221,13 @@ paths:
           format: uri
       - name: publish
         in: query
-        description: 'filter objects depend on their draft status:
+        description: 'filter objects depending on their draft status:
 
-          * all: show all objects
+          * `all`: show all objects
 
-          * draft: show only draft or draft-related objects
+          * `draft`: show only draft or draft-related objects
 
-          * nondraft: show only non-draft or non-draft-related objects (default)
+          * `nondraft`: show only non-draft or non-draft-related objects (default)
 
           '
         required: false
@@ -2817,13 +2817,13 @@ paths:
           - Mede-initiator
       - name: publish
         in: query
-        description: 'filter objects depend on their draft status:
+        description: 'filter objects depending on their draft status:
 
-          * all: show all objects
+          * `all`: show all objects
 
-          * draft: show only draft or draft-related objects
+          * `draft`: show only draft or draft-related objects
 
-          * nondraft: show only non-draft or non-draft-related objects (default)
+          * `nondraft`: show only non-draft or non-draft-related objects (default)
 
           '
         required: false
@@ -3375,13 +3375,13 @@ paths:
           format: uri
       - name: publish
         in: query
-        description: 'filter objects depend on their draft status:
+        description: 'filter objects depending on their draft status:
 
-          * all: show all objects
+          * `all`: show all objects
 
-          * draft: show only draft or draft-related objects
+          * `draft`: show only draft or draft-related objects
 
-          * nondraft: show only non-draft or non-draft-related objects (default)
+          * `nondraft`: show only non-draft or non-draft-related objects (default)
 
           '
         required: false
@@ -3963,13 +3963,13 @@ paths:
           - Uitgaand
       - name: publish
         in: query
-        description: 'filter objects depend on their draft status:
+        description: 'filter objects depending on their draft status:
 
-          * all: show all objects
+          * `all`: show all objects
 
-          * draft: show only draft or draft-related objects
+          * `draft`: show only draft or draft-related objects
 
-          * nondraft: show only non-draft or non-draft-related objects (default)
+          * `nondraft`: show only non-draft or non-draft-related objects (default)
 
           '
         required: false
@@ -4521,13 +4521,13 @@ paths:
           format: uri
       - name: publish
         in: query
-        description: 'filter objects depend on their draft status:
+        description: 'filter objects depending on their draft status:
 
-          * all: show all objects
+          * `all`: show all objects
 
-          * draft: show only draft or draft-related objects
+          * `draft`: show only draft or draft-related objects
 
-          * nondraft: show only non-draft or non-draft-related objects (default)
+          * `nondraft`: show only non-draft or non-draft-related objects (default)
 
           '
         required: false

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -71,6 +71,20 @@ paths:
         schema:
           type: string
           format: uri
+      - name: publish
+        in: query
+        description: 'filter objects depend on their draft status:
+
+          * all: show all objects
+
+          * draft: show only draft or draft-related objects
+
+          * nondraft: show only non-draft or non-draft-related objects (default)
+
+          '
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -1050,6 +1064,20 @@ paths:
         schema:
           type: string
           format: uri
+      - name: publish
+        in: query
+        description: 'filter objects depend on their draft status:
+
+          * all: show all objects
+
+          * draft: show only draft or draft-related objects
+
+          * nondraft: show only non-draft or non-draft-related objects (default)
+
+          '
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -1597,6 +1625,20 @@ paths:
         schema:
           type: string
           format: uri
+      - name: publish
+        in: query
+        description: 'filter objects depend on their draft status:
+
+          * all: show all objects
+
+          * draft: show only draft or draft-related objects
+
+          * nondraft: show only non-draft or non-draft-related objects (default)
+
+          '
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -2177,6 +2219,20 @@ paths:
         schema:
           type: string
           format: uri
+      - name: publish
+        in: query
+        description: 'filter objects depend on their draft status:
+
+          * all: show all objects
+
+          * draft: show only draft or draft-related objects
+
+          * nondraft: show only non-draft or non-draft-related objects (default)
+
+          '
+        required: false
+        schema:
+          type: string
       - name: pagina
         in: query
         description: Een pagina binnen de gepagineerde set resultaten.
@@ -2759,6 +2815,20 @@ paths:
           - Klantcontacter
           - "Zaakco\xF6rdinator"
           - Mede-initiator
+      - name: publish
+        in: query
+        description: 'filter objects depend on their draft status:
+
+          * all: show all objects
+
+          * draft: show only draft or draft-related objects
+
+          * nondraft: show only non-draft or non-draft-related objects (default)
+
+          '
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -3303,6 +3373,20 @@ paths:
         schema:
           type: string
           format: uri
+      - name: publish
+        in: query
+        description: 'filter objects depend on their draft status:
+
+          * all: show all objects
+
+          * draft: show only draft or draft-related objects
+
+          * nondraft: show only non-draft or non-draft-related objects (default)
+
+          '
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -3877,6 +3961,20 @@ paths:
           - Inkomend
           - Intern
           - Uitgaand
+      - name: publish
+        in: query
+        description: 'filter objects depend on their draft status:
+
+          * all: show all objects
+
+          * draft: show only draft or draft-related objects
+
+          * nondraft: show only non-draft or non-draft-related objects (default)
+
+          '
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''
@@ -4421,6 +4519,20 @@ paths:
         schema:
           type: string
           format: uri
+      - name: publish
+        in: query
+        description: 'filter objects depend on their draft status:
+
+          * all: show all objects
+
+          * draft: show only draft or draft-related objects
+
+          * nondraft: show only non-draft or non-draft-related objects (default)
+
+          '
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: ''

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -71,15 +71,15 @@ paths:
         schema:
           type: string
           format: uri
-      - name: publish
+      - name: status
         in: query
-        description: 'filter objects depending on their draft status:
+        description: 'filter objects depending on their concept status:
 
-          * `all`: show all objects
+          * `alles`: toon objecten waarvan het attribuut `concept` true of false is.
 
-          * `draft`: show only draft or draft-related objects
+          * `concept`: toon objecten waarvan het attribuut `concept` true is.
 
-          * `nondraft`: show only non-draft or non-draft-related objects (default)
+          * `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).
 
           '
         required: false
@@ -1064,15 +1064,15 @@ paths:
         schema:
           type: string
           format: uri
-      - name: publish
+      - name: status
         in: query
-        description: 'filter objects depending on their draft status:
+        description: 'filter objects depending on their concept status:
 
-          * `all`: show all objects
+          * `alles`: toon objecten waarvan het attribuut `concept` true of false is.
 
-          * `draft`: show only draft or draft-related objects
+          * `concept`: toon objecten waarvan het attribuut `concept` true is.
 
-          * `nondraft`: show only non-draft or non-draft-related objects (default)
+          * `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).
 
           '
         required: false
@@ -1625,15 +1625,15 @@ paths:
         schema:
           type: string
           format: uri
-      - name: publish
+      - name: status
         in: query
-        description: 'filter objects depending on their draft status:
+        description: 'filter objects depending on their concept status:
 
-          * `all`: show all objects
+          * `alles`: toon objecten waarvan het attribuut `concept` true of false is.
 
-          * `draft`: show only draft or draft-related objects
+          * `concept`: toon objecten waarvan het attribuut `concept` true is.
 
-          * `nondraft`: show only non-draft or non-draft-related objects (default)
+          * `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).
 
           '
         required: false
@@ -2219,15 +2219,15 @@ paths:
         schema:
           type: string
           format: uri
-      - name: publish
+      - name: status
         in: query
-        description: 'filter objects depending on their draft status:
+        description: 'filter objects depending on their concept status:
 
-          * `all`: show all objects
+          * `alles`: toon objecten waarvan het attribuut `concept` true of false is.
 
-          * `draft`: show only draft or draft-related objects
+          * `concept`: toon objecten waarvan het attribuut `concept` true is.
 
-          * `nondraft`: show only non-draft or non-draft-related objects (default)
+          * `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).
 
           '
         required: false
@@ -2815,15 +2815,15 @@ paths:
           - Klantcontacter
           - "Zaakco\xF6rdinator"
           - Mede-initiator
-      - name: publish
+      - name: status
         in: query
-        description: 'filter objects depending on their draft status:
+        description: 'filter objects depending on their concept status:
 
-          * `all`: show all objects
+          * `alles`: toon objecten waarvan het attribuut `concept` true of false is.
 
-          * `draft`: show only draft or draft-related objects
+          * `concept`: toon objecten waarvan het attribuut `concept` true is.
 
-          * `nondraft`: show only non-draft or non-draft-related objects (default)
+          * `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).
 
           '
         required: false
@@ -3373,15 +3373,15 @@ paths:
         schema:
           type: string
           format: uri
-      - name: publish
+      - name: status
         in: query
-        description: 'filter objects depending on their draft status:
+        description: 'filter objects depending on their concept status:
 
-          * `all`: show all objects
+          * `alles`: toon objecten waarvan het attribuut `concept` true of false is.
 
-          * `draft`: show only draft or draft-related objects
+          * `concept`: toon objecten waarvan het attribuut `concept` true is.
 
-          * `nondraft`: show only non-draft or non-draft-related objects (default)
+          * `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).
 
           '
         required: false
@@ -3961,15 +3961,15 @@ paths:
           - Inkomend
           - Intern
           - Uitgaand
-      - name: publish
+      - name: status
         in: query
-        description: 'filter objects depending on their draft status:
+        description: 'filter objects depending on their concept status:
 
-          * `all`: show all objects
+          * `alles`: toon objecten waarvan het attribuut `concept` true of false is.
 
-          * `draft`: show only draft or draft-related objects
+          * `concept`: toon objecten waarvan het attribuut `concept` true is.
 
-          * `nondraft`: show only non-draft or non-draft-related objects (default)
+          * `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).
 
           '
         required: false
@@ -4519,15 +4519,15 @@ paths:
         schema:
           type: string
           format: uri
-      - name: publish
+      - name: status
         in: query
-        description: 'filter objects depending on their draft status:
+        description: 'filter objects depending on their concept status:
 
-          * `all`: show all objects
+          * `alles`: toon objecten waarvan het attribuut `concept` true of false is.
 
-          * `draft`: show only draft or draft-related objects
+          * `concept`: toon objecten waarvan het attribuut `concept` true is.
 
-          * `nondraft`: show only non-draft or non-draft-related objects (default)
+          * `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).
 
           '
         required: false
@@ -5192,9 +5192,11 @@ components:
           description: De datum waarop het is opgeheven.
           type: string
           format: date
-        draft:
-          title: Draft
-          description: Flag indicating the object is a draft
+        concept:
+          title: Concept
+          description: Geeft aan of het object een concept betreft. Concepten zijn
+            niet-definitieve versies en zouden niet gebruikt moeten worden buiten
+            deze API.
           type: boolean
           readOnly: true
     Fout:
@@ -5501,9 +5503,11 @@ components:
           description: De datum waarop het is opgeheven.
           type: string
           format: date
-        draft:
-          title: Draft
-          description: Flag indicating the object is a draft
+        concept:
+          title: Concept
+          description: Geeft aan of het object een concept betreft. Concepten zijn
+            niet-definitieve versies en zouden niet gebruikt moeten worden buiten
+            deze API.
           type: boolean
           readOnly: true
     BrondatumArchiefprocedure:
@@ -5547,9 +5551,37 @@ components:
           description: Het soort object in de registratie dat het procesobject representeert.
           type: string
           enum:
-          - VerblijfsObject
-          - MeldingOpenbareRuimte
-          - InzageVerzoek
+          - adres
+          - besluit
+          - buurt
+          - enkelvoudigDocument
+          - gemeente
+          - gemeentelijkeOpenbareRuimte
+          - huishouden
+          - inrichtingselement
+          - kadastraleOnroerendeZaak
+          - kunstwerkdeel
+          - maatschappelijkeActiviteit
+          - medewerker
+          - natuurlijkPersoon
+          - nietNatuurlijkPersoon
+          - openbareRuimte
+          - organisatorischeEenheid
+          - pand
+          - spoorbaandeel
+          - status
+          - terreindeel
+          - terreinGebouwdObject
+          - vestiging
+          - waterdeel
+          - wegdeel
+          - wijk
+          - woonplaats
+          - wozDeelobject
+          - wozObject
+          - wozWaarde
+          - zakelijkRecht
+          - overige
         registratie:
           title: Registratie
           description: De naam van de registratie waarvan het procesobject deel uit
@@ -6117,8 +6149,10 @@ components:
             geldig zijn geworden
           type: string
           format: date
-        draft:
-          title: Draft
-          description: Flag indicating the object is a draft
+        concept:
+          title: Concept
+          description: Geeft aan of het object een concept betreft. Concepten zijn
+            niet-definitieve versies en zouden niet gebruikt moeten worden buiten
+            deze API.
           type: boolean
           readOnly: true

--- a/src/resources.md
+++ b/src/resources.md
@@ -24,7 +24,7 @@ Objecttype op [GEMMA Online](https://www.gemmaonline.nl/index.php/Imztc_2.1/doc/
 | informatieobjecttypes |  | array | ja | C​R​U​D |
 | beginGeldigheid | De datum waarop het is ontstaan. | string | ja | C​R​U​D |
 | eindeGeldigheid | De datum waarop het is opgeheven. | string | nee | C​R​U​D |
-| draft | Flag indicating the object is a draft | boolean | nee | ~~C~~​R​~~U~~​~~D~~ |
+| concept | Geeft aan of het object een concept betreft. Concepten zijn niet-definitieve versies en zouden niet gebruikt moeten worden buiten deze API. | boolean | nee | ~~C~~​R​~~U~~​~~D~~ |
 
 ## Catalogus
 
@@ -78,7 +78,7 @@ Objecttype op [GEMMA Online](https://www.gemmaonline.nl/index.php/Imztc_2.1/doc/
 | vertrouwelijkheidaanduiding | Aanduiding van de mate waarin informatieobjecten van dit INFORMATIEOBJECTTYPE voor de openbaarheid bestemd zijn. | string | ja | C​R​U​D |
 | beginGeldigheid | De datum waarop het is ontstaan. | string | ja | C​R​U​D |
 | eindeGeldigheid | De datum waarop het is opgeheven. | string | nee | C​R​U​D |
-| draft | Flag indicating the object is a draft | boolean | nee | ~~C~~​R​~~U~~​~~D~~ |
+| concept | Geeft aan of het object een concept betreft. Concepten zijn niet-definitieve versies en zouden niet gebruikt moeten worden buiten deze API. | boolean | nee | ~~C~~​R​~~U~~​~~D~~ |
 
 ## ResultaatType
 
@@ -186,7 +186,7 @@ Objecttype op [GEMMA Online](https://www.gemmaonline.nl/index.php/Imztc_2.1/doc/
 | beginGeldigheid | De datum waarop het is ontstaan. | string | ja | C​R​U​D |
 | eindeGeldigheid | De datum waarop het is opgeheven. | string | nee | C​R​U​D |
 | versiedatum | De datum waarop de (gewijzigde) kenmerken van het ZAAKTYPE geldig zijn geworden | string | ja | C​R​U​D |
-| draft | Flag indicating the object is a draft | boolean | nee | ~~C~~​R​~~U~~​~~D~~ |
+| concept | Geeft aan of het object een concept betreft. Concepten zijn niet-definitieve versies en zouden niet gebruikt moeten worden buiten deze API. | boolean | nee | ~~C~~​R​~~U~~​~~D~~ |
 
 
 * Create, Read, Update, Delete

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -45,6 +45,13 @@
                         "required": false,
                         "type": "string",
                         "format": "uri"
+                    },
+                    {
+                        "name": "publish",
+                        "in": "query",
+                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "required": false,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -1254,6 +1261,13 @@
                         "required": false,
                         "type": "string",
                         "format": "uri"
+                    },
+                    {
+                        "name": "publish",
+                        "in": "query",
+                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "required": false,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -1922,6 +1936,13 @@
                         "required": false,
                         "type": "string",
                         "format": "uri"
+                    },
+                    {
+                        "name": "publish",
+                        "in": "query",
+                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "required": false,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -2642,6 +2663,13 @@
                         "format": "uri"
                     },
                     {
+                        "name": "publish",
+                        "in": "query",
+                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
                         "name": "pagina",
                         "in": "query",
                         "description": "Een pagina binnen de gepagineerde set resultaten.",
@@ -3352,6 +3380,13 @@
                             "Zaakco\u00f6rdinator",
                             "Mede-initiator"
                         ]
+                    },
+                    {
+                        "name": "publish",
+                        "in": "query",
+                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "required": false,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4019,6 +4054,13 @@
                         "required": false,
                         "type": "string",
                         "format": "uri"
+                    },
+                    {
+                        "name": "publish",
+                        "in": "query",
+                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "required": false,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -4707,6 +4749,13 @@
                             "Intern",
                             "Uitgaand"
                         ]
+                    },
+                    {
+                        "name": "publish",
+                        "in": "query",
+                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "required": false,
+                        "type": "string"
                     }
                 ],
                 "responses": {
@@ -5375,6 +5424,13 @@
                         "required": false,
                         "type": "string",
                         "format": "uri"
+                    },
+                    {
+                        "name": "publish",
+                        "in": "query",
+                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "required": false,
+                        "type": "string"
                     }
                 ],
                 "responses": {

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -47,9 +47,9 @@
                         "format": "uri"
                     },
                     {
-                        "name": "publish",
+                        "name": "status",
                         "in": "query",
-                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their concept status:\n* `alles`: toon objecten waarvan het attribuut `concept` true of false is.\n* `concept`: toon objecten waarvan het attribuut `concept` true is.\n* `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).\n",
                         "required": false,
                         "type": "string"
                     }
@@ -1263,9 +1263,9 @@
                         "format": "uri"
                     },
                     {
-                        "name": "publish",
+                        "name": "status",
                         "in": "query",
-                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their concept status:\n* `alles`: toon objecten waarvan het attribuut `concept` true of false is.\n* `concept`: toon objecten waarvan het attribuut `concept` true is.\n* `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).\n",
                         "required": false,
                         "type": "string"
                     }
@@ -1938,9 +1938,9 @@
                         "format": "uri"
                     },
                     {
-                        "name": "publish",
+                        "name": "status",
                         "in": "query",
-                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their concept status:\n* `alles`: toon objecten waarvan het attribuut `concept` true of false is.\n* `concept`: toon objecten waarvan het attribuut `concept` true is.\n* `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).\n",
                         "required": false,
                         "type": "string"
                     }
@@ -2663,9 +2663,9 @@
                         "format": "uri"
                     },
                     {
-                        "name": "publish",
+                        "name": "status",
                         "in": "query",
-                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their concept status:\n* `alles`: toon objecten waarvan het attribuut `concept` true of false is.\n* `concept`: toon objecten waarvan het attribuut `concept` true is.\n* `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).\n",
                         "required": false,
                         "type": "string"
                     },
@@ -3382,9 +3382,9 @@
                         ]
                     },
                     {
-                        "name": "publish",
+                        "name": "status",
                         "in": "query",
-                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their concept status:\n* `alles`: toon objecten waarvan het attribuut `concept` true of false is.\n* `concept`: toon objecten waarvan het attribuut `concept` true is.\n* `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).\n",
                         "required": false,
                         "type": "string"
                     }
@@ -4056,9 +4056,9 @@
                         "format": "uri"
                     },
                     {
-                        "name": "publish",
+                        "name": "status",
                         "in": "query",
-                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their concept status:\n* `alles`: toon objecten waarvan het attribuut `concept` true of false is.\n* `concept`: toon objecten waarvan het attribuut `concept` true is.\n* `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).\n",
                         "required": false,
                         "type": "string"
                     }
@@ -4751,9 +4751,9 @@
                         ]
                     },
                     {
-                        "name": "publish",
+                        "name": "status",
                         "in": "query",
-                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their concept status:\n* `alles`: toon objecten waarvan het attribuut `concept` true of false is.\n* `concept`: toon objecten waarvan het attribuut `concept` true is.\n* `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).\n",
                         "required": false,
                         "type": "string"
                     }
@@ -5426,9 +5426,9 @@
                         "format": "uri"
                     },
                     {
-                        "name": "publish",
+                        "name": "status",
                         "in": "query",
-                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their concept status:\n* `alles`: toon objecten waarvan het attribuut `concept` true of false is.\n* `concept`: toon objecten waarvan het attribuut `concept` true is.\n* `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).\n",
                         "required": false,
                         "type": "string"
                     }
@@ -6233,9 +6233,9 @@
                     "type": "string",
                     "format": "date"
                 },
-                "draft": {
-                    "title": "Draft",
-                    "description": "Flag indicating the object is a draft",
+                "concept": {
+                    "title": "Concept",
+                    "description": "Geeft aan of het object een concept betreft. Concepten zijn niet-definitieve versies en zouden niet gebruikt moeten worden buiten deze API.",
                     "type": "boolean",
                     "readOnly": true
                 }
@@ -6598,9 +6598,9 @@
                     "type": "string",
                     "format": "date"
                 },
-                "draft": {
-                    "title": "Draft",
-                    "description": "Flag indicating the object is a draft",
+                "concept": {
+                    "title": "Concept",
+                    "description": "Geeft aan of het object een concept betreft. Concepten zijn niet-definitieve versies en zouden niet gebruikt moeten worden buiten deze API.",
                     "type": "boolean",
                     "readOnly": true
                 }
@@ -6647,9 +6647,37 @@
                     "description": "Het soort object in de registratie dat het procesobject representeert.",
                     "type": "string",
                     "enum": [
-                        "VerblijfsObject",
-                        "MeldingOpenbareRuimte",
-                        "InzageVerzoek"
+                        "adres",
+                        "besluit",
+                        "buurt",
+                        "enkelvoudigDocument",
+                        "gemeente",
+                        "gemeentelijkeOpenbareRuimte",
+                        "huishouden",
+                        "inrichtingselement",
+                        "kadastraleOnroerendeZaak",
+                        "kunstwerkdeel",
+                        "maatschappelijkeActiviteit",
+                        "medewerker",
+                        "natuurlijkPersoon",
+                        "nietNatuurlijkPersoon",
+                        "openbareRuimte",
+                        "organisatorischeEenheid",
+                        "pand",
+                        "spoorbaandeel",
+                        "status",
+                        "terreindeel",
+                        "terreinGebouwdObject",
+                        "vestiging",
+                        "waterdeel",
+                        "wegdeel",
+                        "wijk",
+                        "woonplaats",
+                        "wozDeelobject",
+                        "wozObject",
+                        "wozWaarde",
+                        "zakelijkRecht",
+                        "overige"
                     ]
                 },
                 "registratie": {
@@ -7257,9 +7285,9 @@
                     "type": "string",
                     "format": "date"
                 },
-                "draft": {
-                    "title": "Draft",
-                    "description": "Flag indicating the object is a draft",
+                "concept": {
+                    "title": "Concept",
+                    "description": "Geeft aan of het object een concept betreft. Concepten zijn niet-definitieve versies en zouden niet gebruikt moeten worden buiten deze API.",
                     "type": "boolean",
                     "readOnly": true
                 }

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -49,7 +49,7 @@
                     {
                         "name": "publish",
                         "in": "query",
-                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
                         "required": false,
                         "type": "string"
                     }
@@ -1265,7 +1265,7 @@
                     {
                         "name": "publish",
                         "in": "query",
-                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
                         "required": false,
                         "type": "string"
                     }
@@ -1940,7 +1940,7 @@
                     {
                         "name": "publish",
                         "in": "query",
-                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
                         "required": false,
                         "type": "string"
                     }
@@ -2665,7 +2665,7 @@
                     {
                         "name": "publish",
                         "in": "query",
-                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
                         "required": false,
                         "type": "string"
                     },
@@ -3384,7 +3384,7 @@
                     {
                         "name": "publish",
                         "in": "query",
-                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
                         "required": false,
                         "type": "string"
                     }
@@ -4058,7 +4058,7 @@
                     {
                         "name": "publish",
                         "in": "query",
-                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
                         "required": false,
                         "type": "string"
                     }
@@ -4753,7 +4753,7 @@
                     {
                         "name": "publish",
                         "in": "query",
-                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
                         "required": false,
                         "type": "string"
                     }
@@ -5428,7 +5428,7 @@
                     {
                         "name": "publish",
                         "in": "query",
-                        "description": "filter objects depend on their draft status:\n* all: show all objects\n* draft: show only draft or draft-related objects\n* nondraft: show only non-draft or non-draft-related objects (default)\n",
+                        "description": "filter objects depending on their draft status:\n* `all`: show all objects\n* `draft`: show only draft or draft-related objects\n* `nondraft`: show only non-draft or non-draft-related objects (default)\n",
                         "required": false,
                         "type": "string"
                     }

--- a/src/ztc/api/filters.py
+++ b/src/ztc/api/filters.py
@@ -7,36 +7,36 @@ from ztc.datamodel.models import (
 )
 
 # custom filter to show concept and non-concepts
-PUBLISH_HELP_TEXT = """filter objects depending on their concept status:
-* `all`: show all objects
-* `concept`: show only concept or concept-related objects
-* `nonconcept`: show only non-concept or non-concept-related objects (default)
+STATUS_HELP_TEXT = """filter objects depending on their concept status:
+* `alles`: toon objecten waarvan het attribuut `concept` true of false is.
+* `concept`: toon objecten waarvan het attribuut `concept` true is.
+* `definitief`: toon objecten waarvan het attribuut `concept` false is (standaard).
 """
 
 
-def publish_filter(queryset, name, value):
+def status_filter(queryset, name, value):
     if value == 'concept':
         return queryset.filter(**{name: True})
-    elif value == 'nonconcept':
+    elif value == 'definitief':
         return queryset.filter(**{name: False})
-    elif value == 'all':
+    elif value == 'alles':
         return queryset
 
 
 class RolTypeFilter(FilterSet):
-    publish = filters.CharFilter(field_name='zaaktype__concept', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+    status = filters.CharFilter(field_name='zaaktype__concept', method=status_filter, help_text=STATUS_HELP_TEXT)
 
     class Meta:
         model = RolType
         fields = (
             'zaaktype',
             'omschrijving_generiek',
-            'publish'
+            'status'
         )
 
 
 class ZaakInformatieobjectTypeFilter(FilterSet):
-    publish = filters.CharFilter(field_name='zaaktype__concept', method='publish_filter_m2m', help_text=PUBLISH_HELP_TEXT)
+    status = filters.CharFilter(field_name='zaaktype__concept', method='status_filter_m2m', help_text=STATUS_HELP_TEXT)
 
     class Meta:
         model = ZaakInformatieobjectType
@@ -44,79 +44,79 @@ class ZaakInformatieobjectTypeFilter(FilterSet):
             'zaaktype',
             'informatie_object_type',
             'richting',
-            'publish',
+            'status',
         )
 
-    def publish_filter_m2m(self, queryset, name, value):
+    def status_filter_m2m(self, queryset, name, value):
         if value == 'concept':
             return queryset.filter(zaaktype__concept=True, informatie_object_type__concept=True)
-        elif value == 'nonconcept':
+        elif value == 'definitief':
             return queryset.filter(zaaktype__concept=False, informatie_object_type__concept=False)
-        elif value == 'all':
+        elif value == 'alles':
             return queryset
 
 
 class ResultaatTypeFilter(FilterSet):
-    publish = filters.CharFilter(field_name='zaaktype__concept', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+    status = filters.CharFilter(field_name='zaaktype__concept', method=status_filter, help_text=STATUS_HELP_TEXT)
 
     class Meta:
         model = ResultaatType
         fields = (
             'zaaktype',
-            'publish'
+            'status'
         )
 
 
 class StatusTypeFilter(FilterSet):
-    publish = filters.CharFilter(field_name='zaaktype__concept', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+    status = filters.CharFilter(field_name='zaaktype__concept', method=status_filter, help_text=STATUS_HELP_TEXT)
 
     class Meta:
         model = StatusType
         fields = (
             'zaaktype',
-            'publish'
+            'status'
         )
 
 
 class EigenschapFilter(FilterSet):
-    publish = filters.CharFilter(field_name='zaaktype__concept', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+    status = filters.CharFilter(field_name='zaaktype__concept', method=status_filter, help_text=STATUS_HELP_TEXT)
 
     class Meta:
         model = Eigenschap
         fields = (
             'zaaktype',
-            'publish'
+            'status'
         )
 
 
 class ZaakTypeFilter(FilterSet):
-    publish = filters.CharFilter(field_name='concept', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+    status = filters.CharFilter(field_name='concept', method=status_filter, help_text=STATUS_HELP_TEXT)
 
     class Meta:
         model = ZaakType
         fields = (
             'catalogus',
-            'publish'
+            'status'
         )
 
 
 class InformatieObjectTypeFilter(FilterSet):
-    publish = filters.CharFilter(field_name='concept', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+    status = filters.CharFilter(field_name='concept', method=status_filter, help_text=STATUS_HELP_TEXT)
 
     class Meta:
         model = InformatieObjectType
         fields = (
             'catalogus',
-            'publish'
+            'status'
         )
 
 
 class BesluitTypeFilter(FilterSet):
-    publish = filters.CharFilter(field_name='concept', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+    status = filters.CharFilter(field_name='concept', method=status_filter, help_text=STATUS_HELP_TEXT)
 
     class Meta:
         model = BesluitType
         fields = (
             'catalogus',
-            'publish'
+            'status'
         )

--- a/src/ztc/api/filters.py
+++ b/src/ztc/api/filters.py
@@ -6,25 +6,25 @@ from ztc.datamodel.models import (
     StatusType, ZaakInformatieobjectType, ZaakType
 )
 
-# custom filter to show draft and non-drafts
-PUBLISH_HELP_TEXT = """filter objects depending on their draft status:
+# custom filter to show concept and non-concepts
+PUBLISH_HELP_TEXT = """filter objects depending on their concept status:
 * `all`: show all objects
-* `draft`: show only draft or draft-related objects
-* `nondraft`: show only non-draft or non-draft-related objects (default)
+* `concept`: show only concept or concept-related objects
+* `nonconcept`: show only non-concept or non-concept-related objects (default)
 """
 
 
 def publish_filter(queryset, name, value):
-    if value == 'draft':
+    if value == 'concept':
         return queryset.filter(**{name: True})
-    elif value == 'nondraft':
+    elif value == 'nonconcept':
         return queryset.filter(**{name: False})
     elif value == 'all':
         return queryset
 
 
 class RolTypeFilter(FilterSet):
-    publish = filters.CharFilter(field_name='zaaktype__draft', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+    publish = filters.CharFilter(field_name='zaaktype__concept', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
 
     class Meta:
         model = RolType
@@ -36,7 +36,7 @@ class RolTypeFilter(FilterSet):
 
 
 class ZaakInformatieobjectTypeFilter(FilterSet):
-    publish = filters.CharFilter(field_name='zaaktype__draft', method='publish_filter_m2m', help_text=PUBLISH_HELP_TEXT)
+    publish = filters.CharFilter(field_name='zaaktype__concept', method='publish_filter_m2m', help_text=PUBLISH_HELP_TEXT)
 
     class Meta:
         model = ZaakInformatieobjectType
@@ -48,16 +48,16 @@ class ZaakInformatieobjectTypeFilter(FilterSet):
         )
 
     def publish_filter_m2m(self, queryset, name, value):
-        if value == 'draft':
-            return queryset.filter(zaaktype__draft=True, informatie_object_type__draft=True)
-        elif value == 'nondraft':
-            return queryset.filter(zaaktype__draft=False, informatie_object_type__draft=False)
+        if value == 'concept':
+            return queryset.filter(zaaktype__concept=True, informatie_object_type__concept=True)
+        elif value == 'nonconcept':
+            return queryset.filter(zaaktype__concept=False, informatie_object_type__concept=False)
         elif value == 'all':
             return queryset
 
 
 class ResultaatTypeFilter(FilterSet):
-    publish = filters.CharFilter(field_name='zaaktype__draft', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+    publish = filters.CharFilter(field_name='zaaktype__concept', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
 
     class Meta:
         model = ResultaatType
@@ -68,7 +68,7 @@ class ResultaatTypeFilter(FilterSet):
 
 
 class StatusTypeFilter(FilterSet):
-    publish = filters.CharFilter(field_name='zaaktype__draft', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+    publish = filters.CharFilter(field_name='zaaktype__concept', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
 
     class Meta:
         model = StatusType
@@ -79,7 +79,7 @@ class StatusTypeFilter(FilterSet):
 
 
 class EigenschapFilter(FilterSet):
-    publish = filters.CharFilter(field_name='zaaktype__draft', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+    publish = filters.CharFilter(field_name='zaaktype__concept', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
 
     class Meta:
         model = Eigenschap
@@ -90,7 +90,7 @@ class EigenschapFilter(FilterSet):
 
 
 class ZaakTypeFilter(FilterSet):
-    publish = filters.CharFilter(field_name='draft', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+    publish = filters.CharFilter(field_name='concept', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
 
     class Meta:
         model = ZaakType
@@ -101,7 +101,7 @@ class ZaakTypeFilter(FilterSet):
 
 
 class InformatieObjectTypeFilter(FilterSet):
-    publish = filters.CharFilter(field_name='draft', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+    publish = filters.CharFilter(field_name='concept', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
 
     class Meta:
         model = InformatieObjectType
@@ -112,7 +112,7 @@ class InformatieObjectTypeFilter(FilterSet):
 
 
 class BesluitTypeFilter(FilterSet):
-    publish = filters.CharFilter(field_name='draft', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+    publish = filters.CharFilter(field_name='concept', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
 
     class Meta:
         model = BesluitType

--- a/src/ztc/api/filters.py
+++ b/src/ztc/api/filters.py
@@ -50,9 +50,9 @@ class ZaakInformatieobjectTypeFilter(FilterSet):
 
     def publish_filter_m2m(self, queryset, name, value):
         if value == 'draft':
-            return queryset.filter(zaaktype__draft=True, informatie_object_type=True)
+            return queryset.filter(zaaktype__draft=True, informatie_object_type__draft=True)
         elif value == 'nondraft':
-            return queryset.filter(zaaktype__draft=False, informatie_object_type=False)
+            return queryset.filter(zaaktype__draft=False, informatie_object_type__draft=False)
         elif value == 'all':
             return queryset
 

--- a/src/ztc/api/filters.py
+++ b/src/ztc/api/filters.py
@@ -1,4 +1,5 @@
 from vng_api_common.filtersets import FilterSet
+from django_filters import rest_framework as filters
 
 from ztc.datamodel.models import (
     BesluitType, Eigenschap, InformatieObjectType, ResultaatType, RolType,
@@ -6,68 +7,117 @@ from ztc.datamodel.models import (
 )
 
 
+# custom filter to show draft and non-drafts
+PUBLISH_HELP_TEXT = """filter objects depending on their draft status:
+* `all`: show all objects
+* `draft`: show only draft or draft-related objects
+* `nondraft`: show only non-draft or non-draft-related objects (default)
+"""
+
+
+def publish_filter(queryset, name, value):
+    if value == 'draft':
+        return queryset.filter(**{name: True})
+    elif value == 'nondraft':
+        return queryset.filter(**{name: False})
+    elif value == 'all':
+        return queryset
+
+
 class RolTypeFilter(FilterSet):
+    publish = filters.CharFilter(field_name='zaaktype__draft', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+
     class Meta:
         model = RolType
         fields = (
             'zaaktype',
             'omschrijving_generiek',
+            'publish'
         )
 
 
 class ZaakInformatieobjectTypeFilter(FilterSet):
+    publish = filters.CharFilter(field_name='zaaktype__draft', method='publish_filter_m2m', help_text=PUBLISH_HELP_TEXT)
+
     class Meta:
         model = ZaakInformatieobjectType
         fields = (
             'zaaktype',
             'informatie_object_type',
             'richting',
+            'publish',
         )
+
+    def publish_filter_m2m(self, queryset, name, value):
+        if value == 'draft':
+            return queryset.filter(zaaktype__draft=True, informatie_object_type=True)
+        elif value == 'nondraft':
+            return queryset.filter(zaaktype__draft=False, informatie_object_type=False)
+        elif value == 'all':
+            return queryset
 
 
 class ResultaatTypeFilter(FilterSet):
+    publish = filters.CharFilter(field_name='zaaktype__draft', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+
     class Meta:
         model = ResultaatType
         fields = (
             'zaaktype',
+            'publish'
         )
 
 
 class StatusTypeFilter(FilterSet):
+    publish = filters.CharFilter(field_name='zaaktype__draft', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+
     class Meta:
         model = StatusType
         fields = (
             'zaaktype',
+            'publish'
         )
 
 
 class EigenschapFilter(FilterSet):
+    publish = filters.CharFilter(field_name='zaaktype__draft', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+
     class Meta:
         model = Eigenschap
         fields = (
             'zaaktype',
+            'publish'
         )
 
 
 class ZaakTypeFilter(FilterSet):
+    publish = filters.CharFilter(field_name='draft', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+
     class Meta:
         model = ZaakType
         fields = (
             'catalogus',
+            'publish'
         )
 
 
 class InformatieObjectTypeFilter(FilterSet):
+    publish = filters.CharFilter(field_name='draft', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+
     class Meta:
         model = InformatieObjectType
         fields = (
             'catalogus',
+            'publish'
         )
 
 
 class BesluitTypeFilter(FilterSet):
+    publish = filters.CharFilter(field_name='draft', method=publish_filter, help_text=PUBLISH_HELP_TEXT)
+
     class Meta:
         model = BesluitType
         fields = (
             'catalogus',
+            'publish'
         )

--- a/src/ztc/api/filters.py
+++ b/src/ztc/api/filters.py
@@ -1,11 +1,10 @@
-from vng_api_common.filtersets import FilterSet
 from django_filters import rest_framework as filters
+from vng_api_common.filtersets import FilterSet
 
 from ztc.datamodel.models import (
     BesluitType, Eigenschap, InformatieObjectType, ResultaatType, RolType,
     StatusType, ZaakInformatieobjectType, ZaakType
 )
-
 
 # custom filter to show draft and non-drafts
 PUBLISH_HELP_TEXT = """filter objects depending on their draft status:

--- a/src/ztc/api/serializers/besluittype.py
+++ b/src/ztc/api/serializers/besluittype.py
@@ -34,7 +34,7 @@ class BesluitTypeSerializer(serializers.HyperlinkedModelSerializer):
             'einde_geldigheid': {
                 'source': 'datum_einde_geldigheid'
             },
-            'draft': {
+            'concept': {
                 'read_only': True,
             },
         }
@@ -55,7 +55,7 @@ class BesluitTypeSerializer(serializers.HyperlinkedModelSerializer):
             'informatieobjecttypes',
             'begin_geldigheid',
             'einde_geldigheid',
-            'draft',
+            'concept',
         )
         validators = [
             RelationCatalogValidator('informatieobjecttypes'),

--- a/src/ztc/api/serializers/informatieobjecttype.py
+++ b/src/ztc/api/serializers/informatieobjecttype.py
@@ -50,7 +50,7 @@ class InformatieObjectTypeSerializer(serializers.HyperlinkedModelSerializer):
             'einde_geldigheid': {
                 'source': 'datum_einde_geldigheid'
             },
-            'draft': {
+            'concept': {
                 'read_only': True,
             },
         }
@@ -62,7 +62,7 @@ class InformatieObjectTypeSerializer(serializers.HyperlinkedModelSerializer):
             'vertrouwelijkheidaanduiding',
             'begin_geldigheid',
             'einde_geldigheid',
-            'draft',
+            'concept',
             # 'omschrijvingGeneriek',
             # 'categorie',
             # 'trefwoord',

--- a/src/ztc/api/serializers/zaken.py
+++ b/src/ztc/api/serializers/zaken.py
@@ -238,7 +238,7 @@ class ZaakTypeSerializer(NestedGegevensGroepMixin, NestedCreateMixin, Hyperlinke
             'begin_geldigheid',
             'einde_geldigheid',
             'versiedatum',
-            'draft',
+            'concept',
         )
         extra_kwargs = {
             'url': {
@@ -268,7 +268,7 @@ class ZaakTypeSerializer(NestedGegevensGroepMixin, NestedCreateMixin, Hyperlinke
             'einde_geldigheid': {
                 'source': 'datum_einde_geldigheid'
             },
-            'draft': {
+            'concept': {
                 'read_only': True,
             },
         }

--- a/src/ztc/api/tests/test_besluittype.py
+++ b/src/ztc/api/tests/test_besluittype.py
@@ -12,7 +12,7 @@ from .utils import reverse
 class BesluitTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list_default_nonconcepts(self):
+    def test_get_list_default_definitief(self):
         besluittype1 = BesluitTypeFactory.create(concept=True)
         besluittype2 = BesluitTypeFactory.create(concept=False)
         besluittype_list_url = reverse('besluittype-list')
@@ -276,25 +276,25 @@ class BesluitTypeAPITests(APITestCase):
 class BesluitTypeFilterAPITests(APITestCase):
     maxDiff = None
 
-    def test_filter_besluittype_publish_all(self):
+    def test_filter_besluittype_status_alles(self):
         BesluitTypeFactory.create(concept=True)
         BesluitTypeFactory.create(concept=False)
         besluittype_list_url = reverse('besluittype-list')
 
-        response = self.client.get(besluittype_list_url, {'publish': 'all'})
+        response = self.client.get(besluittype_list_url, {'status': 'alles'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
 
         self.assertEqual(len(data), 2)
 
-    def test_filter_besluittype_publish_concept(self):
+    def test_filter_besluittype_status_concept(self):
         besluittype1 = BesluitTypeFactory.create(concept=True)
         besluittype2 = BesluitTypeFactory.create(concept=False)
         besluittype_list_url = reverse('besluittype-list')
         besluittype1_url = reverse('besluittype-detail', kwargs={'uuid': besluittype1.uuid})
 
-        response = self.client.get(besluittype_list_url, {'publish': 'concept'})
+        response = self.client.get(besluittype_list_url, {'status': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -302,13 +302,13 @@ class BesluitTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{besluittype1_url}')
 
-    def test_filter_besluittype_publish_nonconcept(self):
+    def test_filter_besluittype_status_definitief(self):
         besluittype1 = BesluitTypeFactory.create(concept=True)
         besluittype2 = BesluitTypeFactory.create(concept=False)
         besluittype_list_url = reverse('besluittype-list')
         besluittype2_url = reverse('besluittype-detail',  kwargs={'uuid': besluittype2.uuid})
 
-        response = self.client.get(besluittype_list_url, {'publish': 'nonconcept'})
+        response = self.client.get(besluittype_list_url, {'status': 'definitief'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_besluittype.py
+++ b/src/ztc/api/tests/test_besluittype.py
@@ -274,3 +274,47 @@ class BesluitTypeAPITests(APITestCase):
 
         data = response.json()
         self.assertEqual(data['detail'], 'Deleting a non-draft object is forbidden')
+
+
+class BesluitTypeFilterAPITests(APITestCase):
+    maxDiff = None
+
+    def test_filter_besluittype_publish_all(self):
+        BesluitTypeFactory.create(draft=True)
+        BesluitTypeFactory.create(draft=False)
+        besluittype_list_url = reverse('besluittype-list')
+
+        response = self.client.get(besluittype_list_url, {'publish': 'all'})
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 2)
+
+    def test_filter_besluittype_publish_draft(self):
+        besluittype1 = BesluitTypeFactory.create(draft=True)
+        besluittype2 = BesluitTypeFactory.create(draft=False)
+        besluittype_list_url = reverse('besluittype-list')
+        besluittype1_url = reverse('besluittype-detail', kwargs={'uuid': besluittype1.uuid})
+
+        response = self.client.get(besluittype_list_url, {'publish': 'draft'})
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{besluittype1_url}')
+
+    def test_filter_besluittype_publish_nondraft(self):
+        besluittype1 = BesluitTypeFactory.create(draft=True)
+        besluittype2 = BesluitTypeFactory.create(draft=False)
+        besluittype_list_url = reverse('besluittype-list')
+        besluittype2_url = reverse('besluittype-detail',  kwargs={'uuid': besluittype2.uuid})
+
+        response = self.client.get(besluittype_list_url, {'publish': 'nondraft'})
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{besluittype2_url}')

--- a/src/ztc/api/tests/test_besluittype.py
+++ b/src/ztc/api/tests/test_besluittype.py
@@ -12,22 +12,19 @@ from .utils import reverse
 class BesluitTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list(self):
-        """Retrieve a list of `BesluitType` objects."""
-        BesluitTypeFactory.create(
-            catalogus=self.catalogus,
-            publicatie_indicatie=True
-        )
+    def test_get_list_default_nondrafts(self):
+        besluittype1 = BesluitTypeFactory.create(draft=True)
+        besluittype2 = BesluitTypeFactory.create(draft=False)
         besluittype_list_url = reverse('besluittype-list')
+        besluittype2_url = reverse('besluittype-detail', kwargs={'uuid': besluittype2.uuid})
 
         response = self.client.get(besluittype_list_url)
-
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
 
-        # pagination disabled for now
         self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{besluittype2_url}')
 
     def test_get_detail(self):
         """Retrieve the details of a single `BesluitType` object."""

--- a/src/ztc/api/tests/test_besluittype.py
+++ b/src/ztc/api/tests/test_besluittype.py
@@ -12,9 +12,9 @@ from .utils import reverse
 class BesluitTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list_default_nondrafts(self):
-        besluittype1 = BesluitTypeFactory.create(draft=True)
-        besluittype2 = BesluitTypeFactory.create(draft=False)
+    def test_get_list_default_nonconcepts(self):
+        besluittype1 = BesluitTypeFactory.create(concept=True)
+        besluittype2 = BesluitTypeFactory.create(concept=False)
         besluittype_list_url = reverse('besluittype-list')
         besluittype2_url = reverse('besluittype-detail', kwargs={'uuid': besluittype2.uuid})
 
@@ -64,7 +64,7 @@ class BesluitTypeAPITests(APITestCase):
             'informatieobjecttypes': [],
             'beginGeldigheid': '2018-01-01',
             'eindeGeldigheid': None,
-            'draft': True,
+            'concept': True,
             # 'resultaattypes': ['http://testserver{resultaattype_url}'],
         }
         self.assertEqual(response.json(), expected)
@@ -104,10 +104,10 @@ class BesluitTypeAPITests(APITestCase):
         self.assertEqual(besluittype.catalogus, self.catalogus)
         self.assertEqual(besluittype.zaaktypes.get(), zaaktype)
         self.assertEqual(besluittype.informatieobjecttypes.get(), informatieobjecttype)
-        self.assertEqual(besluittype.draft, True)
+        self.assertEqual(besluittype.concept, True)
 
-    def test_create_besluittype_fail_non_draft_zaaktypes(self):
-        zaaktype = ZaakTypeFactory.create(draft=False, catalogus=self.catalogus)
+    def test_create_besluittype_fail_non_concept_zaaktypes(self):
+        zaaktype = ZaakTypeFactory.create(concept=False, catalogus=self.catalogus)
         zaaktype_url = reverse('zaaktype-detail', kwargs={
             'uuid': zaaktype.uuid,
         })
@@ -136,14 +136,14 @@ class BesluitTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], "Relations to a non-draft zaaktypes object can't be created")
+        self.assertEqual(data['detail'], "Relations to a non-concept zaaktypes object can't be created")
 
-    def test_create_besluittype_fail_non_draft_informatieobjecttypes(self):
+    def test_create_besluittype_fail_non_concept_informatieobjecttypes(self):
         zaaktype = ZaakTypeFactory.create(catalogus=self.catalogus)
         zaaktype_url = reverse('zaaktype-detail', kwargs={
             'uuid': zaaktype.uuid,
         })
-        informatieobjecttype = InformatieObjectTypeFactory.create(draft=False, catalogus=self.catalogus)
+        informatieobjecttype = InformatieObjectTypeFactory.create(concept=False, catalogus=self.catalogus)
         informatieobjecttype_url = reverse('informatieobjecttype-detail', kwargs={
             'uuid': informatieobjecttype.uuid,
         })
@@ -168,7 +168,7 @@ class BesluitTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], "Relations to a non-draft informatieobjecttypes object can't be created")
+        self.assertEqual(data['detail'], "Relations to a non-concept informatieobjecttypes object can't be created")
 
     def test_create_besluittype_fail_different_catalogus_for_zaaktypes(self):
         zaaktype = ZaakTypeFactory.create()
@@ -246,7 +246,7 @@ class BesluitTypeAPITests(APITestCase):
 
         besluittype.refresh_from_db()
 
-        self.assertEqual(besluittype.draft, False)
+        self.assertEqual(besluittype.concept, False)
 
     def test_delete_besluittype(self):
         besluittype = BesluitTypeFactory.create()
@@ -259,8 +259,8 @@ class BesluitTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(BesluitType.objects.exists())
 
-    def test_delete_besluittype_fail_not_draft(self):
-        besluittype = BesluitTypeFactory.create(draft=False)
+    def test_delete_besluittype_fail_not_concept(self):
+        besluittype = BesluitTypeFactory.create(concept=False)
         besluittype_url = reverse('besluittype-detail', kwargs={
             'uuid': besluittype.uuid,
         })
@@ -270,15 +270,15 @@ class BesluitTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-draft object is forbidden')
+        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
 
 
 class BesluitTypeFilterAPITests(APITestCase):
     maxDiff = None
 
     def test_filter_besluittype_publish_all(self):
-        BesluitTypeFactory.create(draft=True)
-        BesluitTypeFactory.create(draft=False)
+        BesluitTypeFactory.create(concept=True)
+        BesluitTypeFactory.create(concept=False)
         besluittype_list_url = reverse('besluittype-list')
 
         response = self.client.get(besluittype_list_url, {'publish': 'all'})
@@ -288,13 +288,13 @@ class BesluitTypeFilterAPITests(APITestCase):
 
         self.assertEqual(len(data), 2)
 
-    def test_filter_besluittype_publish_draft(self):
-        besluittype1 = BesluitTypeFactory.create(draft=True)
-        besluittype2 = BesluitTypeFactory.create(draft=False)
+    def test_filter_besluittype_publish_concept(self):
+        besluittype1 = BesluitTypeFactory.create(concept=True)
+        besluittype2 = BesluitTypeFactory.create(concept=False)
         besluittype_list_url = reverse('besluittype-list')
         besluittype1_url = reverse('besluittype-detail', kwargs={'uuid': besluittype1.uuid})
 
-        response = self.client.get(besluittype_list_url, {'publish': 'draft'})
+        response = self.client.get(besluittype_list_url, {'publish': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -302,13 +302,13 @@ class BesluitTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{besluittype1_url}')
 
-    def test_filter_besluittype_publish_nondraft(self):
-        besluittype1 = BesluitTypeFactory.create(draft=True)
-        besluittype2 = BesluitTypeFactory.create(draft=False)
+    def test_filter_besluittype_publish_nonconcept(self):
+        besluittype1 = BesluitTypeFactory.create(concept=True)
+        besluittype2 = BesluitTypeFactory.create(concept=False)
         besluittype_list_url = reverse('besluittype-list')
         besluittype2_url = reverse('besluittype-detail',  kwargs={'uuid': besluittype2.uuid})
 
-        response = self.client.get(besluittype_list_url, {'publish': 'nondraft'})
+        response = self.client.get(besluittype_list_url, {'publish': 'nonconcept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_besluittype.py
+++ b/src/ztc/api/tests/test_besluittype.py
@@ -69,6 +69,61 @@ class BesluitTypeAPITests(APITestCase):
         }
         self.assertEqual(response.json(), expected)
 
+    def test_get_detail_related_informatieobjecttypes(self):
+        """Retrieve the details of a single `BesluitType` object with related informatieonnjecttype."""
+        besluittype = BesluitTypeFactory.create(
+            catalogus=self.catalogus,
+            publicatie_indicatie=True,
+        )
+        iot1 = InformatieObjectTypeFactory.create(
+            catalogus=self.catalogus,
+        )
+        iot2 = InformatieObjectTypeFactory.create(
+            catalogus=self.catalogus
+        )
+        besluittype.informatieobjecttypes.add(iot1)
+
+        besluittype_detail_url = reverse('besluittype-detail', kwargs={
+            'uuid': besluittype.uuid
+        })
+        iot1_url = reverse('informatieobjecttype-detail', kwargs={'uuid': iot1.uuid})
+
+        response = self.client.get(besluittype_detail_url)
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertEqual(len(data['informatieobjecttypes']), 1)
+        self.assertEqual(data['informatieobjecttypes'][0], f'http://testserver{iot1_url}')
+
+    def test_get_detail_related_zaaktypes(self):
+        """Retrieve the details of a single `BesluitType` object with related zaaktypes."""
+        besluittype = BesluitTypeFactory.create(
+            catalogus=self.catalogus,
+            publicatie_indicatie=True,
+        )
+        zaaktype1 = ZaakTypeFactory.create(
+            catalogus=self.catalogus,
+        )
+        zaaktype2 = ZaakTypeFactory.create(
+            catalogus=self.catalogus
+        )
+        besluittype.zaaktypes.clear()
+        besluittype.zaaktypes.add(zaaktype1)
+
+        besluittype_detail_url = reverse('besluittype-detail', kwargs={
+            'uuid': besluittype.uuid
+        })
+        zaaktype1_url = reverse('zaaktype-detail', kwargs={'uuid': zaaktype1.uuid})
+
+        response = self.client.get(besluittype_detail_url)
+
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertEqual(len(data['zaaktypes']), 1)
+        self.assertEqual(data['zaaktypes'][0], f'http://testserver{zaaktype1_url}')
+
     def test_create_besluittype(self):
         zaaktype = ZaakTypeFactory.create(catalogus=self.catalogus)
         zaaktype_url = reverse('zaaktype-detail', kwargs={
@@ -270,7 +325,7 @@ class BesluitTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
+        self.assertEqual(data['detail'], 'Alleen concepten kunnen worden verwijderd.')
 
 
 class BesluitTypeFilterAPITests(APITestCase):

--- a/src/ztc/api/tests/test_eigenschap.py
+++ b/src/ztc/api/tests/test_eigenschap.py
@@ -154,3 +154,47 @@ class EigenschapAPITests(APITestCase):
 
         data = response.json()
         self.assertEqual(data['detail'], 'Deleting a non-draft object is forbidden')
+
+
+class EigenschapFilterAPITests(APITestCase):
+    maxDiff = None
+
+    def test_filter_eigenschap_publish_all(self):
+        EigenschapFactory.create(zaaktype__draft=True)
+        EigenschapFactory.create(zaaktype__draft=False)
+        eigenschap_list_url = reverse('eigenschap-list')
+
+        response = self.client.get(eigenschap_list_url, {'publish': 'all'})
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 2)
+
+    def test_filter_eigenschap_publish_draft(self):
+        eigenschap1 = EigenschapFactory.create(zaaktype__draft=True)
+        eigenschap2 = EigenschapFactory.create(zaaktype__draft=False)
+        eigenschap_list_url = reverse('eigenschap-list')
+        eigenschap1_url = reverse('eigenschap-detail', kwargs={'uuid': eigenschap1.uuid})
+
+        response = self.client.get(eigenschap_list_url, {'publish': 'draft'})
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{eigenschap1_url}')
+
+    def test_filter_eigenschap_publish_nondraft(self):
+        eigenschap1 = EigenschapFactory.create(zaaktype__draft=True)
+        eigenschap2 = EigenschapFactory.create(zaaktype__draft=False)
+        eigenschap_list_url = reverse('eigenschap-list')
+        eigenschap2_url = reverse('eigenschap-detail', kwargs={'uuid': eigenschap2.uuid})
+
+        response = self.client.get(eigenschap_list_url, {'publish': 'nondraft'})
+        self.assertEqual(response.status_code , 200)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{eigenschap2_url}')

--- a/src/ztc/api/tests/test_eigenschap.py
+++ b/src/ztc/api/tests/test_eigenschap.py
@@ -16,8 +16,8 @@ class EigenschapAPITests(APITestCase):
     maxDiff = None
 
     def test_get_list_default_nonpublish(self):
-        eigenschap1 = EigenschapFactory.create(zaaktype__draft=True)
-        eigenschap2 = EigenschapFactory.create(zaaktype__draft=False)
+        eigenschap1 = EigenschapFactory.create(zaaktype__concept=True)
+        eigenschap2 = EigenschapFactory.create(zaaktype__concept=False)
         eigenschap_list_url = reverse('eigenschap-list')
         eigenschap2_url = reverse('eigenschap-detail', kwargs={'uuid': eigenschap2.uuid})
 
@@ -119,8 +119,8 @@ class EigenschapAPITests(APITestCase):
         self.assertEqual(eigenschap.eigenschapnaam, 'Beoogd product')
         self.assertEqual(eigenschap.zaaktype, zaaktype)
 
-    def test_create_eigenschap_fail_not_draft_zaaktype(self):
-        zaaktype = ZaakTypeFactory.create(draft=False)
+    def test_create_eigenschap_fail_not_concept_zaaktype(self):
+        zaaktype = ZaakTypeFactory.create(concept=False)
         zaaktype_url = reverse('zaaktype-detail', kwargs={'uuid': zaaktype.uuid})
         eigenschap_list_url = reverse('eigenschap-list')
         data = {
@@ -135,7 +135,7 @@ class EigenschapAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Creating a related object to non-draft object is forbidden')
+        self.assertEqual(data['detail'], 'Creating a related object to non-concept object is forbidden')
 
     def test_delete_eigenschap(self):
         eigenschap = EigenschapFactory.create()
@@ -146,8 +146,8 @@ class EigenschapAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Eigenschap.objects.filter(id=eigenschap.id))
 
-    def test_delete_eigenschap_fail_not_draft_zaaktype(self):
-        eigenschap = EigenschapFactory.create(zaaktype__draft=False)
+    def test_delete_eigenschap_fail_not_concept_zaaktype(self):
+        eigenschap = EigenschapFactory.create(zaaktype__concept=False)
         informatieobjecttypee_url = reverse('eigenschap-detail', kwargs={'uuid': eigenschap.uuid})
 
         response = self.client.delete(informatieobjecttypee_url)
@@ -155,15 +155,15 @@ class EigenschapAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-draft object is forbidden')
+        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
 
 
 class EigenschapFilterAPITests(APITestCase):
     maxDiff = None
 
     def test_filter_eigenschap_publish_all(self):
-        EigenschapFactory.create(zaaktype__draft=True)
-        EigenschapFactory.create(zaaktype__draft=False)
+        EigenschapFactory.create(zaaktype__concept=True)
+        EigenschapFactory.create(zaaktype__concept=False)
         eigenschap_list_url = reverse('eigenschap-list')
 
         response = self.client.get(eigenschap_list_url, {'publish': 'all'})
@@ -173,13 +173,13 @@ class EigenschapFilterAPITests(APITestCase):
 
         self.assertEqual(len(data), 2)
 
-    def test_filter_eigenschap_publish_draft(self):
-        eigenschap1 = EigenschapFactory.create(zaaktype__draft=True)
-        eigenschap2 = EigenschapFactory.create(zaaktype__draft=False)
+    def test_filter_eigenschap_publish_concept(self):
+        eigenschap1 = EigenschapFactory.create(zaaktype__concept=True)
+        eigenschap2 = EigenschapFactory.create(zaaktype__concept=False)
         eigenschap_list_url = reverse('eigenschap-list')
         eigenschap1_url = reverse('eigenschap-detail', kwargs={'uuid': eigenschap1.uuid})
 
-        response = self.client.get(eigenschap_list_url, {'publish': 'draft'})
+        response = self.client.get(eigenschap_list_url, {'publish': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -187,13 +187,13 @@ class EigenschapFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{eigenschap1_url}')
 
-    def test_filter_eigenschap_publish_nondraft(self):
-        eigenschap1 = EigenschapFactory.create(zaaktype__draft=True)
-        eigenschap2 = EigenschapFactory.create(zaaktype__draft=False)
+    def test_filter_eigenschap_publish_nonconcept(self):
+        eigenschap1 = EigenschapFactory.create(zaaktype__concept=True)
+        eigenschap2 = EigenschapFactory.create(zaaktype__concept=False)
         eigenschap_list_url = reverse('eigenschap-list')
         eigenschap2_url = reverse('eigenschap-detail', kwargs={'uuid': eigenschap2.uuid})
 
-        response = self.client.get(eigenschap_list_url, {'publish': 'nondraft'})
+        response = self.client.get(eigenschap_list_url, {'publish': 'nonconcept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_eigenschap.py
+++ b/src/ztc/api/tests/test_eigenschap.py
@@ -155,7 +155,7 @@ class EigenschapAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
+        self.assertEqual(data['detail'], 'Alleen concepten kunnen worden verwijderd.')
 
 
 class EigenschapFilterAPITests(APITestCase):

--- a/src/ztc/api/tests/test_eigenschap.py
+++ b/src/ztc/api/tests/test_eigenschap.py
@@ -15,17 +15,19 @@ from .utils import reverse
 class EigenschapAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list(self):
-        EigenschapFactory.create_batch(2)
+    def test_get_list_default_nonpublish(self):
+        eigenschap1 = EigenschapFactory.create(zaaktype__draft=True)
+        eigenschap2 = EigenschapFactory.create(zaaktype__draft=False)
         eigenschap_list_url = reverse('eigenschap-list')
+        eigenschap2_url = reverse('eigenschap-detail', kwargs={'uuid': eigenschap2.uuid})
 
-        response = self.api_client.get(eigenschap_list_url)
-
+        response = self.client.get(eigenschap_list_url)
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
 
-        self.assertEqual(len(data), 2)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{eigenschap2_url}')
 
     def test_get_detail(self):
         zaaktype = ZaakTypeFactory.create(catalogus=self.catalogus)
@@ -192,7 +194,7 @@ class EigenschapFilterAPITests(APITestCase):
         eigenschap2_url = reverse('eigenschap-detail', kwargs={'uuid': eigenschap2.uuid})
 
         response = self.client.get(eigenschap_list_url, {'publish': 'nondraft'})
-        self.assertEqual(response.status_code , 200)
+        self.assertEqual(response.status_code, 200)
 
         data = response.json()
 

--- a/src/ztc/api/tests/test_eigenschap.py
+++ b/src/ztc/api/tests/test_eigenschap.py
@@ -15,7 +15,7 @@ from .utils import reverse
 class EigenschapAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list_default_nonpublish(self):
+    def test_get_list_default_definitief(self):
         eigenschap1 = EigenschapFactory.create(zaaktype__concept=True)
         eigenschap2 = EigenschapFactory.create(zaaktype__concept=False)
         eigenschap_list_url = reverse('eigenschap-list')
@@ -161,25 +161,25 @@ class EigenschapAPITests(APITestCase):
 class EigenschapFilterAPITests(APITestCase):
     maxDiff = None
 
-    def test_filter_eigenschap_publish_all(self):
+    def test_filter_eigenschap_status_alles(self):
         EigenschapFactory.create(zaaktype__concept=True)
         EigenschapFactory.create(zaaktype__concept=False)
         eigenschap_list_url = reverse('eigenschap-list')
 
-        response = self.client.get(eigenschap_list_url, {'publish': 'all'})
+        response = self.client.get(eigenschap_list_url, {'status': 'alles'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
 
         self.assertEqual(len(data), 2)
 
-    def test_filter_eigenschap_publish_concept(self):
+    def test_filter_eigenschap_status_concept(self):
         eigenschap1 = EigenschapFactory.create(zaaktype__concept=True)
         eigenschap2 = EigenschapFactory.create(zaaktype__concept=False)
         eigenschap_list_url = reverse('eigenschap-list')
         eigenschap1_url = reverse('eigenschap-detail', kwargs={'uuid': eigenschap1.uuid})
 
-        response = self.client.get(eigenschap_list_url, {'publish': 'concept'})
+        response = self.client.get(eigenschap_list_url, {'status': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -187,13 +187,13 @@ class EigenschapFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{eigenschap1_url}')
 
-    def test_filter_eigenschap_publish_nonconcept(self):
+    def test_filter_eigenschap_status_definitief(self):
         eigenschap1 = EigenschapFactory.create(zaaktype__concept=True)
         eigenschap2 = EigenschapFactory.create(zaaktype__concept=False)
         eigenschap_list_url = reverse('eigenschap-list')
         eigenschap2_url = reverse('eigenschap-detail', kwargs={'uuid': eigenschap2.uuid})
 
-        response = self.client.get(eigenschap_list_url, {'publish': 'nonconcept'})
+        response = self.client.get(eigenschap_list_url, {'status': 'definitief'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_informatieobjecttype.py
+++ b/src/ztc/api/tests/test_informatieobjecttype.py
@@ -17,18 +17,19 @@ from .base import APITestCase
 class InformatieObjectTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list(self):
-        """Retrieve a list of `InformatieObjectType` objects."""
-        InformatieObjectTypeFactory.create()
+    def test_get_list_default_nondraft(self):
+        informatieobjecttype1 = InformatieObjectTypeFactory.create(draft=True)
+        informatieobjecttype2 = InformatieObjectTypeFactory.create(draft=False)
         informatieobjecttype_list_url = get_operation_url('informatieobjecttype_list')
+        informatieobjecttype2_url = get_operation_url('informatieobjecttype_read',  uuid=informatieobjecttype2.uuid)
 
         response = self.client.get(informatieobjecttype_list_url)
-
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
 
         self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{informatieobjecttype2_url}')
 
     def test_get_detail(self):
         """Retrieve the details of a single `InformatieObjectType` object."""

--- a/src/ztc/api/tests/test_informatieobjecttype.py
+++ b/src/ztc/api/tests/test_informatieobjecttype.py
@@ -160,7 +160,7 @@ class InformatieObjectTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
+        self.assertEqual(data['detail'], 'Alleen concepten kunnen worden verwijderd.')
 
 
 class InformatieObjectTypeFilterAPITests(APITestCase):

--- a/src/ztc/api/tests/test_informatieobjecttype.py
+++ b/src/ztc/api/tests/test_informatieobjecttype.py
@@ -17,9 +17,9 @@ from .base import APITestCase
 class InformatieObjectTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list_default_nondraft(self):
-        informatieobjecttype1 = InformatieObjectTypeFactory.create(draft=True)
-        informatieobjecttype2 = InformatieObjectTypeFactory.create(draft=False)
+    def test_get_list_default_nonconcept(self):
+        informatieobjecttype1 = InformatieObjectTypeFactory.create(concept=True)
+        informatieobjecttype2 = InformatieObjectTypeFactory.create(concept=False)
         informatieobjecttype_list_url = get_operation_url('informatieobjecttype_list')
         informatieobjecttype2_url = get_operation_url('informatieobjecttype_read',  uuid=informatieobjecttype2.uuid)
 
@@ -66,7 +66,7 @@ class InformatieObjectTypeAPITests(APITestCase):
             # 'isRelevantVoor': [],
             'beginGeldigheid': '2019-01-01',
             'eindeGeldigheid': None,
-            'draft': True,
+            'concept': True,
         }
         self.assertEqual(expected, response.json())
 
@@ -128,7 +128,7 @@ class InformatieObjectTypeAPITests(APITestCase):
 
         self.assertEqual(informatieobjecttype.omschrijving, 'test')
         self.assertEqual(informatieobjecttype.catalogus, self.catalogus)
-        self.assertEqual(informatieobjecttype.draft, True)
+        self.assertEqual(informatieobjecttype.concept, True)
 
     def test_publish_informatieobjecttype(self):
         informatieobjecttype = InformatieObjectTypeFactory.create()
@@ -140,7 +140,7 @@ class InformatieObjectTypeAPITests(APITestCase):
 
         informatieobjecttype.refresh_from_db()
 
-        self.assertEqual(informatieobjecttype.draft, False)
+        self.assertEqual(informatieobjecttype.concept, False)
 
     def test_delete_informatieobjecttype(self):
         informatieobjecttype = InformatieObjectTypeFactory.create()
@@ -151,8 +151,8 @@ class InformatieObjectTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(InformatieObjectType.objects.filter(id=informatieobjecttype.id))
 
-    def test_delete_informatieobjecttype_fail_not_draft(self):
-        informatieobjecttype = InformatieObjectTypeFactory.create(draft=False)
+    def test_delete_informatieobjecttype_fail_not_concept(self):
+        informatieobjecttype = InformatieObjectTypeFactory.create(concept=False)
         informatieobjecttypee_url = get_operation_url('informatieobjecttype_read', uuid=informatieobjecttype.uuid)
 
         response = self.client.delete(informatieobjecttypee_url)
@@ -160,15 +160,15 @@ class InformatieObjectTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-draft object is forbidden')
+        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
 
 
 class InformatieObjectTypeFilterAPITests(APITestCase):
     maxDiff = None
 
     def test_filter_informatieobjecttype_publish_all(self):
-        InformatieObjectTypeFactory.create(draft=True)
-        InformatieObjectTypeFactory.create(draft=False)
+        InformatieObjectTypeFactory.create(concept=True)
+        InformatieObjectTypeFactory.create(concept=False)
         informatieobjecttype_list_url = get_operation_url('informatieobjecttype_list')
 
         response = self.client.get(informatieobjecttype_list_url, {'publish': 'all'})
@@ -178,13 +178,13 @@ class InformatieObjectTypeFilterAPITests(APITestCase):
 
         self.assertEqual(len(data), 2)
 
-    def test_filter_informatieobjecttype_publish_draft(self):
-        informatieobjecttype1 = InformatieObjectTypeFactory.create(draft=True)
-        informatieobjecttype2 = InformatieObjectTypeFactory.create(draft=False)
+    def test_filter_informatieobjecttype_publish_concept(self):
+        informatieobjecttype1 = InformatieObjectTypeFactory.create(concept=True)
+        informatieobjecttype2 = InformatieObjectTypeFactory.create(concept=False)
         informatieobjecttype_list_url = get_operation_url('informatieobjecttype_list')
         informatieobjecttype1_url = get_operation_url('informatieobjecttype_read', uuid=informatieobjecttype1.uuid)
 
-        response = self.client.get(informatieobjecttype_list_url, {'publish': 'draft'})
+        response = self.client.get(informatieobjecttype_list_url, {'publish': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -192,13 +192,13 @@ class InformatieObjectTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{informatieobjecttype1_url}')
 
-    def test_filter_informatieobjecttype_publish_nondraft(self):
-        informatieobjecttype1 = InformatieObjectTypeFactory.create(draft=True)
-        informatieobjecttype2 = InformatieObjectTypeFactory.create(draft=False)
+    def test_filter_informatieobjecttype_publish_nonconcept(self):
+        informatieobjecttype1 = InformatieObjectTypeFactory.create(concept=True)
+        informatieobjecttype2 = InformatieObjectTypeFactory.create(concept=False)
         informatieobjecttype_list_url = get_operation_url('informatieobjecttype_list')
         informatieobjecttype2_url = get_operation_url('informatieobjecttype_read',  uuid=informatieobjecttype2.uuid)
 
-        response = self.client.get(informatieobjecttype_list_url, {'publish': 'nondraft'})
+        response = self.client.get(informatieobjecttype_list_url, {'publish': 'nonconcept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_informatieobjecttype.py
+++ b/src/ztc/api/tests/test_informatieobjecttype.py
@@ -17,7 +17,7 @@ from .base import APITestCase
 class InformatieObjectTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list_default_nonconcept(self):
+    def test_get_list_default_definitief(self):
         informatieobjecttype1 = InformatieObjectTypeFactory.create(concept=True)
         informatieobjecttype2 = InformatieObjectTypeFactory.create(concept=False)
         informatieobjecttype_list_url = get_operation_url('informatieobjecttype_list')
@@ -166,25 +166,25 @@ class InformatieObjectTypeAPITests(APITestCase):
 class InformatieObjectTypeFilterAPITests(APITestCase):
     maxDiff = None
 
-    def test_filter_informatieobjecttype_publish_all(self):
+    def test_filter_informatieobjecttype_status_alles(self):
         InformatieObjectTypeFactory.create(concept=True)
         InformatieObjectTypeFactory.create(concept=False)
         informatieobjecttype_list_url = get_operation_url('informatieobjecttype_list')
 
-        response = self.client.get(informatieobjecttype_list_url, {'publish': 'all'})
+        response = self.client.get(informatieobjecttype_list_url, {'status': 'alles'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
 
         self.assertEqual(len(data), 2)
 
-    def test_filter_informatieobjecttype_publish_concept(self):
+    def test_filter_informatieobjecttype_status_concept(self):
         informatieobjecttype1 = InformatieObjectTypeFactory.create(concept=True)
         informatieobjecttype2 = InformatieObjectTypeFactory.create(concept=False)
         informatieobjecttype_list_url = get_operation_url('informatieobjecttype_list')
         informatieobjecttype1_url = get_operation_url('informatieobjecttype_read', uuid=informatieobjecttype1.uuid)
 
-        response = self.client.get(informatieobjecttype_list_url, {'publish': 'concept'})
+        response = self.client.get(informatieobjecttype_list_url, {'status': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -192,13 +192,13 @@ class InformatieObjectTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{informatieobjecttype1_url}')
 
-    def test_filter_informatieobjecttype_publish_nonconcept(self):
+    def test_filter_informatieobjecttype_status_definitief(self):
         informatieobjecttype1 = InformatieObjectTypeFactory.create(concept=True)
         informatieobjecttype2 = InformatieObjectTypeFactory.create(concept=False)
         informatieobjecttype_list_url = get_operation_url('informatieobjecttype_list')
         informatieobjecttype2_url = get_operation_url('informatieobjecttype_read',  uuid=informatieobjecttype2.uuid)
 
-        response = self.client.get(informatieobjecttype_list_url, {'publish': 'nonconcept'})
+        response = self.client.get(informatieobjecttype_list_url, {'status': 'definitief'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_relatieklassen.py
+++ b/src/ztc/api/tests/test_relatieklassen.py
@@ -18,7 +18,7 @@ class ZaakInformatieobjectTypeAPITests(APITestCase):
 
     list_url = reverse_lazy(ZaakInformatieobjectType)
 
-    def test_get_list_default_nonconcept(self):
+    def test_get_list_default_definitief(self):
         ziot1 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=True)
         ziot2 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=True)
         ziot3 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=False)
@@ -190,27 +190,27 @@ class ZaakInformatieobjectTypeFilterAPITests(APITestCase):
         self.assertEqual(response.json()[0]['informatieObjectType'], informatie_object_type1_url)
         self.assertNotEqual(response.json()[0]['informatieObjectType'], informatie_object_type2_url)
 
-    def test_filter_ziot_publish_all(self):
+    def test_filter_ziot_status_alles(self):
         ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=True)
         ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=True)
         ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=False)
         ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=False)
 
-        response = self.client.get(self.list_url, {'publish': 'all'})
+        response = self.client.get(self.list_url, {'status': 'alles'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
 
         self.assertEqual(len(data), 4)
 
-    def test_filter_ziot_publish_concept(self):
+    def test_filter_ziot_status_concept(self):
         ziot1 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=True)
         ziot2 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=True)
         ziot3 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=False)
         ziot4 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=False)
         ziot1_url = reverse(ziot1)
 
-        response = self.client.get(self.list_url, {'publish': 'concept'})
+        response = self.client.get(self.list_url, {'status': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -218,14 +218,14 @@ class ZaakInformatieobjectTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{ziot1_url}')
 
-    def test_filter_ziot_publish_nonconcept(self):
+    def test_filter_ziot_status_definitief(self):
         ziot1 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=True)
         ziot2 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=True)
         ziot3 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=False)
         ziot4 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=False)
         ziot4_url = reverse(ziot4)
 
-        response = self.client.get(self.list_url, {'publish': 'nonconcept'})
+        response = self.client.get(self.list_url, {'status': 'definitief'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_relatieklassen.py
+++ b/src/ztc/api/tests/test_relatieklassen.py
@@ -18,11 +18,11 @@ class ZaakInformatieobjectTypeAPITests(APITestCase):
 
     list_url = reverse_lazy(ZaakInformatieobjectType)
 
-    def test_get_list_default_nondraft(self):
-        ziot1 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=True, informatie_object_type__draft=True)
-        ziot2 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False, informatie_object_type__draft=True)
-        ziot3 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=True, informatie_object_type__draft=False)
-        ziot4 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False, informatie_object_type__draft=False)
+    def test_get_list_default_nonconcept(self):
+        ziot1 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=True)
+        ziot2 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=True)
+        ziot3 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=False)
+        ziot4 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=False)
         ziot4_url = reverse(ziot4)
 
         response = self.client.get(self.list_url)
@@ -75,8 +75,8 @@ class ZaakInformatieobjectTypeAPITests(APITestCase):
         self.assertEqual(ziot.zaaktype, zaaktype)
         self.assertEqual(ziot.informatie_object_type, informatieobjecttype)
 
-    def test_create_ziot_fail_not_draft_zaaktype(self):
-        zaaktype = ZaakTypeFactory.create(draft=False)
+    def test_create_ziot_fail_not_concept_zaaktype(self):
+        zaaktype = ZaakTypeFactory.create(concept=False)
         zaaktype_url = reverse(zaaktype)
         informatieobjecttype = InformatieObjectTypeFactory.create()
         informatieobjecttype_url = reverse(informatieobjecttype)
@@ -92,12 +92,12 @@ class ZaakInformatieobjectTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Creating relations between non-draft objects is forbidden')
+        self.assertEqual(data['detail'], 'Creating relations between non-concept objects is forbidden')
 
-    def test_create_ziot_fail_not_draft_informatieobjecttype(self):
+    def test_create_ziot_fail_not_concept_informatieobjecttype(self):
         zaaktype = ZaakTypeFactory.create()
         zaaktype_url = reverse(zaaktype)
-        informatieobjecttype = InformatieObjectTypeFactory.create(draft=False)
+        informatieobjecttype = InformatieObjectTypeFactory.create(concept=False)
         informatieobjecttype_url = reverse(informatieobjecttype)
         data = {
             'zaaktype': f'http://testserver{zaaktype_url}',
@@ -111,7 +111,7 @@ class ZaakInformatieobjectTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Creating relations between non-draft objects is forbidden')
+        self.assertEqual(data['detail'], 'Creating relations between non-concept objects is forbidden')
 
     def test_delete_ziot(self):
         ziot = ZaakInformatieobjectTypeFactory.create()
@@ -122,8 +122,8 @@ class ZaakInformatieobjectTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(ZaakInformatieobjectType.objects.filter(id=ziot.id))
 
-    def test_delete_ziot_fail_not_draft_zaaktype(self):
-        ziot = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False)
+    def test_delete_ziot_fail_not_concept_zaaktype(self):
+        ziot = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False)
         ziot_url = reverse(ziot)
 
         response = self.client.delete(ziot_url)
@@ -131,10 +131,10 @@ class ZaakInformatieobjectTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-draft object is forbidden')
+        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
 
-    def test_delete_ziot_fail_not_draft_informatieobjecttype(self):
-        ziot = ZaakInformatieobjectTypeFactory.create(informatie_object_type__draft=False)
+    def test_delete_ziot_fail_not_concept_informatieobjecttype(self):
+        ziot = ZaakInformatieobjectTypeFactory.create(informatie_object_type__concept=False)
         ziot_url = reverse(ziot)
 
         response = self.client.delete(ziot_url)
@@ -142,7 +142,7 @@ class ZaakInformatieobjectTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-draft object is forbidden')
+        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
 
 
 class ZaakInformatieobjectTypeFilterAPITests(APITestCase):
@@ -152,8 +152,8 @@ class ZaakInformatieobjectTypeFilterAPITests(APITestCase):
     def test_filter_zaaktype(self):
         ztiot1, ztiot2 = ZaakInformatieobjectTypeFactory.create_batch(
             2,
-            zaaktype__draft=False,
-            informatie_object_type__draft=False
+            zaaktype__concept=False,
+            informatie_object_type__concept=False
         )
         url = f'http://testserver{reverse(ztiot1)}'
         zaaktype1_url = reverse(ztiot1.zaaktype)
@@ -173,8 +173,8 @@ class ZaakInformatieobjectTypeFilterAPITests(APITestCase):
     def test_filter_informatieobjecttype(self):
         ztiot1, ztiot2 = ZaakInformatieobjectTypeFactory.create_batch(
             2,
-            zaaktype__draft=False,
-            informatie_object_type__draft=False
+            zaaktype__concept=False,
+            informatie_object_type__concept=False
         )
         url = f'http://testserver{reverse(ztiot1)}'
         informatie_object_type1_url = reverse(ztiot1.informatie_object_type)
@@ -191,10 +191,10 @@ class ZaakInformatieobjectTypeFilterAPITests(APITestCase):
         self.assertNotEqual(response.json()[0]['informatieObjectType'], informatie_object_type2_url)
 
     def test_filter_ziot_publish_all(self):
-        ZaakInformatieobjectTypeFactory.create(zaaktype__draft=True, informatie_object_type__draft=True)
-        ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False, informatie_object_type__draft=True)
-        ZaakInformatieobjectTypeFactory.create(zaaktype__draft=True, informatie_object_type__draft=False)
-        ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False, informatie_object_type__draft=False)
+        ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=True)
+        ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=True)
+        ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=False)
+        ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=False)
 
         response = self.client.get(self.list_url, {'publish': 'all'})
         self.assertEqual(response.status_code, 200)
@@ -203,14 +203,14 @@ class ZaakInformatieobjectTypeFilterAPITests(APITestCase):
 
         self.assertEqual(len(data), 4)
 
-    def test_filter_ziot_publish_draft(self):
-        ziot1 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=True, informatie_object_type__draft=True)
-        ziot2 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False, informatie_object_type__draft=True)
-        ziot3 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=True, informatie_object_type__draft=False)
-        ziot4 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False, informatie_object_type__draft=False)
+    def test_filter_ziot_publish_concept(self):
+        ziot1 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=True)
+        ziot2 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=True)
+        ziot3 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=False)
+        ziot4 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=False)
         ziot1_url = reverse(ziot1)
 
-        response = self.client.get(self.list_url, {'publish': 'draft'})
+        response = self.client.get(self.list_url, {'publish': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -218,14 +218,14 @@ class ZaakInformatieobjectTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{ziot1_url}')
 
-    def test_filter_ziot_publish_nondraft(self):
-        ziot1 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=True, informatie_object_type__draft=True)
-        ziot2 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False, informatie_object_type__draft=True)
-        ziot3 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=True, informatie_object_type__draft=False)
-        ziot4 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False, informatie_object_type__draft=False)
+    def test_filter_ziot_publish_nonconcept(self):
+        ziot1 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=True)
+        ziot2 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=True)
+        ziot3 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=True, informatie_object_type__concept=False)
+        ziot4 = ZaakInformatieobjectTypeFactory.create(zaaktype__concept=False, informatie_object_type__concept=False)
         ziot4_url = reverse(ziot4)
 
-        response = self.client.get(self.list_url, {'publish': 'nondraft'})
+        response = self.client.get(self.list_url, {'publish': 'nonconcept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_relatieklassen.py
+++ b/src/ztc/api/tests/test_relatieklassen.py
@@ -170,6 +170,54 @@ class ZaakInformatieobjectTypeAPITests(APITestCase):
         self.assertEqual(data['detail'], 'Deleting a non-draft object is forbidden')
 
 
+class ZaakInformatieobjectTypeFilterAPITests(APITestCase):
+    maxDiff = None
+    list_url = reverse_lazy(ZaakInformatieobjectType)
+
+    def test_filter_ziot_publish_all(self):
+        ZaakInformatieobjectTypeFactory.create(zaaktype__draft=True, informatie_object_type__draft=True)
+        ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False, informatie_object_type__draft=True)
+        ZaakInformatieobjectTypeFactory.create(zaaktype__draft=True, informatie_object_type__draft=False)
+        ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False, informatie_object_type__draft=False)
+
+        response = self.client.get(self.list_url, {'publish': 'all'})
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 4)
+
+    def test_filter_ziot_publish_draft(self):
+        ziot1 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=True, informatie_object_type__draft=True)
+        ziot2 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False, informatie_object_type__draft=True)
+        ziot3 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=True, informatie_object_type__draft=False)
+        ziot4 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False, informatie_object_type__draft=False)
+        ziot1_url = reverse(ziot1)
+
+        response = self.client.get(self.list_url, {'publish': 'draft'})
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{ziot1_url}')
+
+    def test_filter_ziot_publish_nondraft(self):
+        ziot1 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=True, informatie_object_type__draft=True)
+        ziot2 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False, informatie_object_type__draft=True)
+        ziot3 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=True, informatie_object_type__draft=False)
+        ziot4 = ZaakInformatieobjectTypeFactory.create(zaaktype__draft=False, informatie_object_type__draft=False)
+        ziot4_url = reverse(ziot4)
+
+        response = self.client.get(self.list_url, {'publish': 'nondraft'})
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{ziot4_url}')
+
+
 @skip("Not MVP yet")
 class ZaakInformatieobjectTypeArchiefregimeAPITests(APITestCase):
     maxDiff = None

--- a/src/ztc/api/tests/test_relatieklassen.py
+++ b/src/ztc/api/tests/test_relatieklassen.py
@@ -131,7 +131,7 @@ class ZaakInformatieobjectTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
+        self.assertEqual(data['detail'], 'Alleen concepten kunnen worden verwijderd.')
 
     def test_delete_ziot_fail_not_concept_informatieobjecttype(self):
         ziot = ZaakInformatieobjectTypeFactory.create(informatie_object_type__concept=False)
@@ -142,7 +142,7 @@ class ZaakInformatieobjectTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
+        self.assertEqual(data['detail'], 'Alleen concepten kunnen worden verwijderd.')
 
 
 class ZaakInformatieobjectTypeFilterAPITests(APITestCase):

--- a/src/ztc/api/tests/test_resultaattype.py
+++ b/src/ztc/api/tests/test_resultaattype.py
@@ -15,7 +15,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
     list_url = reverse_lazy(ResultaatType)
 
     def test_get_list(self):
-        ResultaatTypeFactory.create_batch(3)
+        ResultaatTypeFactory.create_batch(3, zaaktype__draft=False)
 
         response = self.api_client.get(self.list_url)
 
@@ -38,28 +38,19 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
             )
         )
 
-    def test_filter_on_zaaktype(self):
-        zt1, zt2 = ZaakTypeFactory.create_batch(2)
-        rt1 = ResultaatTypeFactory.create(zaaktype=zt1)
-        rt1_url = f'http://testserver{reverse(rt1)}'
-        rt2 = ResultaatTypeFactory.create(zaaktype=zt2)
-        rt2_url = f'http://testserver{reverse(rt2)}'
-        zt1_url = 'http://testserver{}'.format(reverse('zaaktype-detail', kwargs={
-            'uuid': zt1.uuid,
-        }))
-        zt2_url = 'http://testserver{}'.format(reverse('zaaktype-detail', kwargs={
-            'uuid': zt2.uuid,
-        }))
+    def test_get_list_default_nondraft(self):
+        resultaattype1 = ResultaatTypeFactory.create(zaaktype__draft=True)
+        resultaattype2 = ResultaatTypeFactory.create(zaaktype__draft=False)
+        resultaattype_list_url = reverse('resultaattype-list')
+        resultaattype2_url = reverse('resultaattype-detail', kwargs={'uuid': resultaattype2.uuid})
 
-        response = self.client.get(self.list_url, {'zaaktype': zt1_url})
+        response = self.client.get(resultaattype_list_url)
+        self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_data = response.json()
-        self.assertEqual(len(response_data), 1)
-        self.assertEqual(response_data[0]['url'], rt1_url)
-        self.assertEqual(response_data[0]['zaaktype'], zt1_url)
-        self.assertNotEqual(response_data[0]['url'], rt2_url)
-        self.assertNotEqual(response_data[0]['zaaktype'], zt2_url)
+        data = response.json()
+
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{resultaattype2_url}')
 
     def test_get_detail(self):
         resultaattype = ResultaatTypeFactory.create()
@@ -227,6 +218,30 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
 class ResultaatTypeFilterAPITests(APITestCase):
     maxDiff = None
 
+    def test_filter_on_zaaktype(self):
+        zt1, zt2 = ZaakTypeFactory.create_batch(2, draft=False)
+        rt1 = ResultaatTypeFactory.create(zaaktype=zt1)
+        rt1_url = f'http://testserver{reverse(rt1)}'
+        rt2 = ResultaatTypeFactory.create(zaaktype=zt2)
+        rt2_url = f'http://testserver{reverse(rt2)}'
+        zt1_url = 'http://testserver{}'.format(reverse('zaaktype-detail', kwargs={
+            'uuid': zt1.uuid,
+        }))
+        zt2_url = 'http://testserver{}'.format(reverse('zaaktype-detail', kwargs={
+            'uuid': zt2.uuid,
+        }))
+        list_url = reverse('resultaattype-list')
+
+        response = self.client.get(list_url, {'zaaktype': zt1_url})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(len(response_data), 1)
+        self.assertEqual(response_data[0]['url'], rt1_url)
+        self.assertEqual(response_data[0]['zaaktype'], zt1_url)
+        self.assertNotEqual(response_data[0]['url'], rt2_url)
+        self.assertNotEqual(response_data[0]['zaaktype'], zt2_url)
+
     def test_filter_resultaattype_publish_all(self):
         ResultaatTypeFactory.create(zaaktype__draft=True)
         ResultaatTypeFactory.create(zaaktype__draft=False)
@@ -260,7 +275,7 @@ class ResultaatTypeFilterAPITests(APITestCase):
         resultaattype2_url = reverse('resultaattype-detail', kwargs={'uuid': resultaattype2.uuid})
 
         response = self.client.get(resultaattype_list_url, {'publish': 'nondraft'})
-        self.assertEqual(response.status_code , 200)
+        self.assertEqual(response.status_code, 200)
 
         data = response.json()
 

--- a/src/ztc/api/tests/test_resultaattype.py
+++ b/src/ztc/api/tests/test_resultaattype.py
@@ -38,7 +38,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
             )
         )
 
-    def test_get_list_default_nonconcept(self):
+    def test_get_list_default_definitief(self):
         resultaattype1 = ResultaatTypeFactory.create(zaaktype__concept=True)
         resultaattype2 = ResultaatTypeFactory.create(zaaktype__concept=False)
         resultaattype_list_url = reverse('resultaattype-list')
@@ -242,25 +242,25 @@ class ResultaatTypeFilterAPITests(APITestCase):
         self.assertNotEqual(response_data[0]['url'], rt2_url)
         self.assertNotEqual(response_data[0]['zaaktype'], zt2_url)
 
-    def test_filter_resultaattype_publish_all(self):
+    def test_filter_resultaattype_status_alles(self):
         ResultaatTypeFactory.create(zaaktype__concept=True)
         ResultaatTypeFactory.create(zaaktype__concept=False)
         resultaattype_list_url = reverse('resultaattype-list')
 
-        response = self.client.get(resultaattype_list_url, {'publish': 'all'})
+        response = self.client.get(resultaattype_list_url, {'status': 'alles'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
 
         self.assertEqual(len(data), 2)
 
-    def test_filter_resultaattype_publish_concept(self):
+    def test_filter_resultaattype_status_concept(self):
         resultaattype1 = ResultaatTypeFactory.create(zaaktype__concept=True)
         resultaattype2 = ResultaatTypeFactory.create(zaaktype__concept=False)
         resultaattype_list_url = reverse('resultaattype-list')
         resultaattype1_url = reverse('resultaattype-detail', kwargs={'uuid': resultaattype1.uuid})
 
-        response = self.client.get(resultaattype_list_url, {'publish': 'concept'})
+        response = self.client.get(resultaattype_list_url, {'status': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -268,13 +268,13 @@ class ResultaatTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{resultaattype1_url}')
 
-    def test_filter_resultaattype_publish_nonconcept(self):
+    def test_filter_resultaattype_status_definitief(self):
         resultaattype1 = ResultaatTypeFactory.create(zaaktype__concept=True)
         resultaattype2 = ResultaatTypeFactory.create(zaaktype__concept=False)
         resultaattype_list_url = reverse('resultaattype-list')
         resultaattype2_url = reverse('resultaattype-detail', kwargs={'uuid': resultaattype2.uuid})
 
-        response = self.client.get(resultaattype_list_url, {'publish': 'nonconcept'})
+        response = self.client.get(resultaattype_list_url, {'status': 'definitief'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_resultaattype.py
+++ b/src/ztc/api/tests/test_resultaattype.py
@@ -212,7 +212,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
+        self.assertEqual(data['detail'], 'Alleen concepten kunnen worden verwijderd.')
 
 
 class ResultaatTypeFilterAPITests(APITestCase):

--- a/src/ztc/api/tests/test_resultaattype.py
+++ b/src/ztc/api/tests/test_resultaattype.py
@@ -15,7 +15,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
     list_url = reverse_lazy(ResultaatType)
 
     def test_get_list(self):
-        ResultaatTypeFactory.create_batch(3, zaaktype__draft=False)
+        ResultaatTypeFactory.create_batch(3, zaaktype__concept=False)
 
         response = self.api_client.get(self.list_url)
 
@@ -38,9 +38,9 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
             )
         )
 
-    def test_get_list_default_nondraft(self):
-        resultaattype1 = ResultaatTypeFactory.create(zaaktype__draft=True)
-        resultaattype2 = ResultaatTypeFactory.create(zaaktype__draft=False)
+    def test_get_list_default_nonconcept(self):
+        resultaattype1 = ResultaatTypeFactory.create(zaaktype__concept=True)
+        resultaattype2 = ResultaatTypeFactory.create(zaaktype__concept=False)
         resultaattype_list_url = reverse('resultaattype-list')
         resultaattype2_url = reverse('resultaattype-detail', kwargs={'uuid': resultaattype2.uuid})
 
@@ -160,8 +160,8 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
             BrondatumArchiefprocedureAfleidingswijze.afgehandeld
         )
 
-    def test_create_resultaattype_fail_not_draft_zaaktype(self):
-        zaaktype = ZaakTypeFactory.create(draft=False)
+    def test_create_resultaattype_fail_not_concept_zaaktype(self):
+        zaaktype = ZaakTypeFactory.create(concept=False)
         zaaktype_url = reverse('zaaktype-detail', kwargs={
             'uuid': zaaktype.uuid,
         })
@@ -192,7 +192,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Creating a related object to non-draft object is forbidden')
+        self.assertEqual(data['detail'], 'Creating a related object to non-concept object is forbidden')
 
     def test_delete_resultaattype(self):
         resultaattype = ResultaatTypeFactory.create()
@@ -203,8 +203,8 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(ResultaatType.objects.filter(id=resultaattype.id))
 
-    def test_delete_resultaattype_fail_not_draft_zaaktype(self):
-        resultaattype = ResultaatTypeFactory.create(zaaktype__draft=False)
+    def test_delete_resultaattype_fail_not_concept_zaaktype(self):
+        resultaattype = ResultaatTypeFactory.create(zaaktype__concept=False)
         resultaattype_url = reverse('resultaattype-detail', kwargs={'uuid': resultaattype.uuid})
 
         response = self.client.delete(resultaattype_url)
@@ -212,14 +212,14 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-draft object is forbidden')
+        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
 
 
 class ResultaatTypeFilterAPITests(APITestCase):
     maxDiff = None
 
     def test_filter_on_zaaktype(self):
-        zt1, zt2 = ZaakTypeFactory.create_batch(2, draft=False)
+        zt1, zt2 = ZaakTypeFactory.create_batch(2, concept=False)
         rt1 = ResultaatTypeFactory.create(zaaktype=zt1)
         rt1_url = f'http://testserver{reverse(rt1)}'
         rt2 = ResultaatTypeFactory.create(zaaktype=zt2)
@@ -243,8 +243,8 @@ class ResultaatTypeFilterAPITests(APITestCase):
         self.assertNotEqual(response_data[0]['zaaktype'], zt2_url)
 
     def test_filter_resultaattype_publish_all(self):
-        ResultaatTypeFactory.create(zaaktype__draft=True)
-        ResultaatTypeFactory.create(zaaktype__draft=False)
+        ResultaatTypeFactory.create(zaaktype__concept=True)
+        ResultaatTypeFactory.create(zaaktype__concept=False)
         resultaattype_list_url = reverse('resultaattype-list')
 
         response = self.client.get(resultaattype_list_url, {'publish': 'all'})
@@ -254,13 +254,13 @@ class ResultaatTypeFilterAPITests(APITestCase):
 
         self.assertEqual(len(data), 2)
 
-    def test_filter_resultaattype_publish_draft(self):
-        resultaattype1 = ResultaatTypeFactory.create(zaaktype__draft=True)
-        resultaattype2 = ResultaatTypeFactory.create(zaaktype__draft=False)
+    def test_filter_resultaattype_publish_concept(self):
+        resultaattype1 = ResultaatTypeFactory.create(zaaktype__concept=True)
+        resultaattype2 = ResultaatTypeFactory.create(zaaktype__concept=False)
         resultaattype_list_url = reverse('resultaattype-list')
         resultaattype1_url = reverse('resultaattype-detail', kwargs={'uuid': resultaattype1.uuid})
 
-        response = self.client.get(resultaattype_list_url, {'publish': 'draft'})
+        response = self.client.get(resultaattype_list_url, {'publish': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -268,13 +268,13 @@ class ResultaatTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{resultaattype1_url}')
 
-    def test_filter_resultaattype_publish_nondraft(self):
-        resultaattype1 = ResultaatTypeFactory.create(zaaktype__draft=True)
-        resultaattype2 = ResultaatTypeFactory.create(zaaktype__draft=False)
+    def test_filter_resultaattype_publish_nonconcept(self):
+        resultaattype1 = ResultaatTypeFactory.create(zaaktype__concept=True)
+        resultaattype2 = ResultaatTypeFactory.create(zaaktype__concept=False)
         resultaattype_list_url = reverse('resultaattype-list')
         resultaattype2_url = reverse('resultaattype-detail', kwargs={'uuid': resultaattype2.uuid})
 
-        response = self.client.get(resultaattype_list_url, {'publish': 'nondraft'})
+        response = self.client.get(resultaattype_list_url, {'publish': 'nonconcept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_roltype.py
+++ b/src/ztc/api/tests/test_roltype.py
@@ -10,9 +10,9 @@ from .utils import reverse
 class RolTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list_default_nondraft(self):
-        roltype1 = RolTypeFactory.create(zaaktype__draft=True)
-        roltype2 = RolTypeFactory.create(zaaktype__draft=False)
+    def test_get_list_default_nonconcept(self):
+        roltype1 = RolTypeFactory.create(zaaktype__concept=True)
+        roltype2 = RolTypeFactory.create(zaaktype__concept=False)
         roltype_list_url = reverse('roltype-list')
         roltype2_url = reverse('roltype-detail', kwargs={'uuid': roltype2.uuid})
 
@@ -80,8 +80,8 @@ class RolTypeAPITests(APITestCase):
         self.assertEqual(roltype.omschrijving, 'Vergunningaanvrager')
         self.assertEqual(roltype.zaaktype, zaaktype)
 
-    def test_create_roltype_fail_not_draft_zaaktype(self):
-        zaaktype = ZaakTypeFactory.create(draft=False)
+    def test_create_roltype_fail_not_concept_zaaktype(self):
+        zaaktype = ZaakTypeFactory.create(concept=False)
         zaaktype_url = reverse('zaaktype-detail', kwargs={
             'uuid': zaaktype.uuid,
         })
@@ -98,7 +98,7 @@ class RolTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Creating a related object to non-draft object is forbidden')
+        self.assertEqual(data['detail'], 'Creating a related object to non-concept object is forbidden')
 
     def test_delete_roltype(self):
         roltype = RolTypeFactory.create()
@@ -109,8 +109,8 @@ class RolTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(RolType.objects.filter(id=roltype.id))
 
-    def test_delete_roltype_fail_not_draft_zaaktype(self):
-        roltype = RolTypeFactory.create(zaaktype__draft=False)
+    def test_delete_roltype_fail_not_concept_zaaktype(self):
+        roltype = RolTypeFactory.create(zaaktype__concept=False)
         roltype_url = reverse('roltype-detail', kwargs={'uuid': roltype.uuid})
 
         response = self.client.delete(roltype_url)
@@ -118,7 +118,7 @@ class RolTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-draft object is forbidden')
+        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
 
 
 class FilterValidationTests(APITestCase):
@@ -141,8 +141,8 @@ class RolTypeFilterAPITests(APITestCase):
     maxDiff = None
 
     def test_filter_roltype_publish_all(self):
-        RolTypeFactory.create(zaaktype__draft=True)
-        RolTypeFactory.create(zaaktype__draft=False)
+        RolTypeFactory.create(zaaktype__concept=True)
+        RolTypeFactory.create(zaaktype__concept=False)
         roltype_list_url = reverse('roltype-list')
 
         response = self.client.get(roltype_list_url, {'publish': 'all'})
@@ -152,13 +152,13 @@ class RolTypeFilterAPITests(APITestCase):
 
         self.assertEqual(len(data), 2)
 
-    def test_filter_roltype_publish_draft(self):
-        roltype1 = RolTypeFactory.create(zaaktype__draft=True)
-        roltype2 = RolTypeFactory.create(zaaktype__draft=False)
+    def test_filter_roltype_publish_concept(self):
+        roltype1 = RolTypeFactory.create(zaaktype__concept=True)
+        roltype2 = RolTypeFactory.create(zaaktype__concept=False)
         roltype_list_url = reverse('roltype-list')
         roltype1_url = reverse('roltype-detail', kwargs={'uuid': roltype1.uuid})
 
-        response = self.client.get(roltype_list_url, {'publish': 'draft'})
+        response = self.client.get(roltype_list_url, {'publish': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -166,13 +166,13 @@ class RolTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{roltype1_url}')
 
-    def test_filter_roltype_publish_nondraft(self):
-        roltype1 = RolTypeFactory.create(zaaktype__draft=True)
-        roltype2 = RolTypeFactory.create(zaaktype__draft=False)
+    def test_filter_roltype_publish_nonconcept(self):
+        roltype1 = RolTypeFactory.create(zaaktype__concept=True)
+        roltype2 = RolTypeFactory.create(zaaktype__concept=False)
         roltype_list_url = reverse('roltype-list')
         roltype2_url = reverse('roltype-detail', kwargs={'uuid': roltype2.uuid})
 
-        response = self.client.get(roltype_list_url, {'publish': 'nondraft'})
+        response = self.client.get(roltype_list_url, {'publish': 'nonconcept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_roltype.py
+++ b/src/ztc/api/tests/test_roltype.py
@@ -10,7 +10,7 @@ from .utils import reverse
 class RolTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list_default_nonconcept(self):
+    def test_get_list_default_definitief(self):
         roltype1 = RolTypeFactory.create(zaaktype__concept=True)
         roltype2 = RolTypeFactory.create(zaaktype__concept=False)
         roltype_list_url = reverse('roltype-list')
@@ -140,25 +140,25 @@ class FilterValidationTests(APITestCase):
 class RolTypeFilterAPITests(APITestCase):
     maxDiff = None
 
-    def test_filter_roltype_publish_all(self):
+    def test_filter_roltype_status_alles(self):
         RolTypeFactory.create(zaaktype__concept=True)
         RolTypeFactory.create(zaaktype__concept=False)
         roltype_list_url = reverse('roltype-list')
 
-        response = self.client.get(roltype_list_url, {'publish': 'all'})
+        response = self.client.get(roltype_list_url, {'status': 'alles'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
 
         self.assertEqual(len(data), 2)
 
-    def test_filter_roltype_publish_concept(self):
+    def test_filter_roltype_status_concept(self):
         roltype1 = RolTypeFactory.create(zaaktype__concept=True)
         roltype2 = RolTypeFactory.create(zaaktype__concept=False)
         roltype_list_url = reverse('roltype-list')
         roltype1_url = reverse('roltype-detail', kwargs={'uuid': roltype1.uuid})
 
-        response = self.client.get(roltype_list_url, {'publish': 'concept'})
+        response = self.client.get(roltype_list_url, {'status': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -166,13 +166,13 @@ class RolTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{roltype1_url}')
 
-    def test_filter_roltype_publish_nonconcept(self):
+    def test_filter_roltype_status_definitief(self):
         roltype1 = RolTypeFactory.create(zaaktype__concept=True)
         roltype2 = RolTypeFactory.create(zaaktype__concept=False)
         roltype_list_url = reverse('roltype-list')
         roltype2_url = reverse('roltype-detail', kwargs={'uuid': roltype2.uuid})
 
-        response = self.client.get(roltype_list_url, {'publish': 'nonconcept'})
+        response = self.client.get(roltype_list_url, {'status': 'definitief'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_roltype.py
+++ b/src/ztc/api/tests/test_roltype.py
@@ -140,3 +140,47 @@ class FilterValidationTests(APITestCase):
             with self.subTest(query_param=key, value=value):
                 response = self.client.get(url, {key: value})
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class RolTypeFilterAPITests(APITestCase):
+    maxDiff = None
+
+    def test_filter_roltype_publish_all(self):
+        RolTypeFactory.create(zaaktype__draft=True)
+        RolTypeFactory.create(zaaktype__draft=False)
+        roltype_list_url = reverse('roltype-list')
+
+        response = self.client.get(roltype_list_url, {'publish': 'all'})
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 2)
+
+    def test_filter_roltype_publish_draft(self):
+        roltype1 = RolTypeFactory.create(zaaktype__draft=True)
+        roltype2 = RolTypeFactory.create(zaaktype__draft=False)
+        roltype_list_url = reverse('roltype-list')
+        roltype1_url = reverse('roltype-detail', kwargs={'uuid': roltype1.uuid})
+
+        response = self.client.get(roltype_list_url, {'publish': 'draft'})
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{roltype1_url}')
+
+    def test_filter_roltype_publish_nondraft(self):
+        roltype1 = RolTypeFactory.create(zaaktype__draft=True)
+        roltype2 = RolTypeFactory.create(zaaktype__draft=False)
+        roltype_list_url = reverse('roltype-list')
+        roltype2_url = reverse('roltype-detail', kwargs={'uuid': roltype2.uuid})
+
+        response = self.client.get(roltype_list_url, {'publish': 'nondraft'})
+        self.assertEqual(response.status_code , 200)
+
+        data = response.json()
+
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{roltype2_url}')

--- a/src/ztc/api/tests/test_roltype.py
+++ b/src/ztc/api/tests/test_roltype.py
@@ -10,24 +10,19 @@ from .utils import reverse
 class RolTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list(self):
-        RolTypeFactory.create(
-            omschrijving='Vergunningaanvrager',
-            omschrijving_generiek=RolOmschrijving.initiator,
-            soort_betrokkene=['Aanvrager'],
-            zaaktype__catalogus=self.catalogus,
-        )
-        rol_type_list_url = reverse('roltype-list')
+    def test_get_list_default_nondraft(self):
+        roltype1 = RolTypeFactory.create(zaaktype__draft=True)
+        roltype2 = RolTypeFactory.create(zaaktype__draft=False)
+        roltype_list_url = reverse('roltype-list')
+        roltype2_url = reverse('roltype-detail', kwargs={'uuid': roltype2.uuid})
 
-        response = self.client.get(rol_type_list_url)
+        response = self.client.get(roltype_list_url)
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
 
-        # TODO: when pagination gets re-added
-        # self.assertTrue('results' in data)
-        # self.assertEqual(len(data['results']), 1)
         self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{roltype2_url}')
 
     def test_get_detail(self):
         rol_type = RolTypeFactory.create(
@@ -178,7 +173,7 @@ class RolTypeFilterAPITests(APITestCase):
         roltype2_url = reverse('roltype-detail', kwargs={'uuid': roltype2.uuid})
 
         response = self.client.get(roltype_list_url, {'publish': 'nondraft'})
-        self.assertEqual(response.status_code , 200)
+        self.assertEqual(response.status_code, 200)
 
         data = response.json()
 

--- a/src/ztc/api/tests/test_roltype.py
+++ b/src/ztc/api/tests/test_roltype.py
@@ -118,7 +118,7 @@ class RolTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
+        self.assertEqual(data['detail'], 'Alleen concepten kunnen worden verwijderd.')
 
 
 class FilterValidationTests(APITestCase):

--- a/src/ztc/api/tests/test_statustype.py
+++ b/src/ztc/api/tests/test_statustype.py
@@ -10,9 +10,9 @@ from .utils import reverse
 class StatusTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list_default_nondraft(self):
-        statustype1 = StatusTypeFactory.create(zaaktype__draft=True)
-        statustype2 = StatusTypeFactory.create(zaaktype__draft=False)
+    def test_get_list_default_nonconcept(self):
+        statustype1 = StatusTypeFactory.create(zaaktype__concept=True)
+        statustype2 = StatusTypeFactory.create(zaaktype__concept=False)
         statustype_list_url = reverse('statustype-list')
         statustype2_url = reverse('statustype-detail', kwargs={'uuid': statustype2.uuid})
 
@@ -75,8 +75,8 @@ class StatusTypeAPITests(APITestCase):
         self.assertEqual(statustype.statustype_omschrijving, 'Besluit genomen')
         self.assertEqual(statustype.zaaktype, zaaktype)
 
-    def test_create_statustype_fail_not_draft_zaaktype(self):
-        zaaktype = ZaakTypeFactory.create(draft=False)
+    def test_create_statustype_fail_not_concept_zaaktype(self):
+        zaaktype = ZaakTypeFactory.create(concept=False)
         zaaktype_url = reverse('zaaktype-detail', kwargs={
             'uuid': zaaktype.uuid,
         })
@@ -93,7 +93,7 @@ class StatusTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Creating a related object to non-draft object is forbidden')
+        self.assertEqual(data['detail'], 'Creating a related object to non-concept object is forbidden')
 
     def test_delete_statustype(self):
         statustype = StatusTypeFactory.create()
@@ -104,8 +104,8 @@ class StatusTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(StatusType.objects.filter(id=statustype.id))
 
-    def test_delete_statustype_fail_not_draft_zaaktype(self):
-        statustype = StatusTypeFactory.create(zaaktype__draft=False)
+    def test_delete_statustype_fail_not_concept_zaaktype(self):
+        statustype = StatusTypeFactory.create(zaaktype__concept=False)
         statustype_url = reverse('statustype-detail', kwargs={'uuid': statustype.uuid})
 
         response = self.client.delete(statustype_url)
@@ -113,15 +113,15 @@ class StatusTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-draft object is forbidden')
+        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
 
 
 class StatusTypeFilterAPITests(APITestCase):
     maxDiff = None
 
     def test_filter_statustype_publish_all(self):
-        StatusTypeFactory.create(zaaktype__draft=True)
-        StatusTypeFactory.create(zaaktype__draft=False)
+        StatusTypeFactory.create(zaaktype__concept=True)
+        StatusTypeFactory.create(zaaktype__concept=False)
         statustype_list_url = reverse('statustype-list')
 
         response = self.client.get(statustype_list_url, {'publish': 'all'})
@@ -131,13 +131,13 @@ class StatusTypeFilterAPITests(APITestCase):
 
         self.assertEqual(len(data), 2)
 
-    def test_filter_statustype_publish_draft(self):
-        statustype1 = StatusTypeFactory.create(zaaktype__draft=True)
-        statustype2 = StatusTypeFactory.create(zaaktype__draft=False)
+    def test_filter_statustype_publish_concept(self):
+        statustype1 = StatusTypeFactory.create(zaaktype__concept=True)
+        statustype2 = StatusTypeFactory.create(zaaktype__concept=False)
         statustype_list_url = reverse('statustype-list')
         statustype1_url = reverse('statustype-detail', kwargs={'uuid': statustype1.uuid})
 
-        response = self.client.get(statustype_list_url, {'publish': 'draft'})
+        response = self.client.get(statustype_list_url, {'publish': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -145,13 +145,13 @@ class StatusTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{statustype1_url}')
 
-    def test_filter_statustype_publish_nondraft(self):
-        statustype1 = StatusTypeFactory.create(zaaktype__draft=True)
-        statustype2 = StatusTypeFactory.create(zaaktype__draft=False)
+    def test_filter_statustype_publish_nonconcept(self):
+        statustype1 = StatusTypeFactory.create(zaaktype__concept=True)
+        statustype2 = StatusTypeFactory.create(zaaktype__concept=False)
         statustype_list_url = reverse('statustype-list')
         statustype2_url = reverse('statustype-detail', kwargs={'uuid': statustype2.uuid})
 
-        response = self.client.get(statustype_list_url, {'publish': 'nondraft'})
+        response = self.client.get(statustype_list_url, {'publish': 'nonconcept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_statustype.py
+++ b/src/ztc/api/tests/test_statustype.py
@@ -10,7 +10,7 @@ from .utils import reverse
 class StatusTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list_default_nonconcept(self):
+    def test_get_list_default_definitief(self):
         statustype1 = StatusTypeFactory.create(zaaktype__concept=True)
         statustype2 = StatusTypeFactory.create(zaaktype__concept=False)
         statustype_list_url = reverse('statustype-list')
@@ -119,25 +119,25 @@ class StatusTypeAPITests(APITestCase):
 class StatusTypeFilterAPITests(APITestCase):
     maxDiff = None
 
-    def test_filter_statustype_publish_all(self):
+    def test_filter_statustype_status_alles(self):
         StatusTypeFactory.create(zaaktype__concept=True)
         StatusTypeFactory.create(zaaktype__concept=False)
         statustype_list_url = reverse('statustype-list')
 
-        response = self.client.get(statustype_list_url, {'publish': 'all'})
+        response = self.client.get(statustype_list_url, {'status': 'alles'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
 
         self.assertEqual(len(data), 2)
 
-    def test_filter_statustype_publish_concept(self):
+    def test_filter_statustype_status_concept(self):
         statustype1 = StatusTypeFactory.create(zaaktype__concept=True)
         statustype2 = StatusTypeFactory.create(zaaktype__concept=False)
         statustype_list_url = reverse('statustype-list')
         statustype1_url = reverse('statustype-detail', kwargs={'uuid': statustype1.uuid})
 
-        response = self.client.get(statustype_list_url, {'publish': 'concept'})
+        response = self.client.get(statustype_list_url, {'status': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -145,13 +145,13 @@ class StatusTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{statustype1_url}')
 
-    def test_filter_statustype_publish_nonconcept(self):
+    def test_filter_statustype_status_definitief(self):
         statustype1 = StatusTypeFactory.create(zaaktype__concept=True)
         statustype2 = StatusTypeFactory.create(zaaktype__concept=False)
         statustype_list_url = reverse('statustype-list')
         statustype2_url = reverse('statustype-detail', kwargs={'uuid': statustype2.uuid})
 
-        response = self.client.get(statustype_list_url, {'publish': 'nonconcept'})
+        response = self.client.get(statustype_list_url, {'status': 'definitief'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_statustype.py
+++ b/src/ztc/api/tests/test_statustype.py
@@ -113,7 +113,7 @@ class StatusTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
+        self.assertEqual(data['detail'], 'Alleen concepten kunnen worden verwijderd.')
 
 
 class StatusTypeFilterAPITests(APITestCase):

--- a/src/ztc/api/tests/test_statustype.py
+++ b/src/ztc/api/tests/test_statustype.py
@@ -10,20 +10,19 @@ from .utils import reverse
 class StatusTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list(self):
-        StatusTypeFactory.create(
-            statustype_omschrijving='Besluit genomen',
-            zaaktype__catalogus=self.catalogus,
-        )
+    def test_get_list_default_nondraft(self):
+        statustype1 = StatusTypeFactory.create(zaaktype__draft=True)
+        statustype2 = StatusTypeFactory.create(zaaktype__draft=False)
         statustype_list_url = reverse('statustype-list')
+        statustype2_url = reverse('statustype-detail', kwargs={'uuid': statustype2.uuid})
 
-        response = self.api_client.get(statustype_list_url)
-
+        response = self.client.get(statustype_list_url)
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
 
         self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{statustype2_url}')
 
     def test_get_detail(self):
         status_type = StatusTypeFactory.create(

--- a/src/ztc/api/tests/test_zaken.py
+++ b/src/ztc/api/tests/test_zaken.py
@@ -19,9 +19,9 @@ from .base import APITestCase
 class ZaakTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list_default_nondraft(self):
-        zaaktype1 = ZaakTypeFactory.create(draft=True)
-        zaaktype2 = ZaakTypeFactory.create(draft=False)
+    def test_get_list_default_nonconcept(self):
+        zaaktype1 = ZaakTypeFactory.create(concept=True)
+        zaaktype2 = ZaakTypeFactory.create(concept=False)
         zaaktype_list_url = get_operation_url('zaaktype_list')
         zaaktype2_url = get_operation_url('zaaktype_read', uuid=zaaktype2.uuid)
 
@@ -92,7 +92,7 @@ class ZaakTypeAPITests(APITestCase):
             'beginGeldigheid': '2018-01-01',
             'eindeGeldigheid': None,
             'versiedatum': '2018-01-01',
-            'draft': True,
+            'concept': True,
         }
         self.assertEqual(expected, response.json())
 
@@ -166,10 +166,10 @@ class ZaakTypeAPITests(APITestCase):
         self.assertEqual(zaaktype.besluittype_set.get(), besluittype)
         self.assertEqual(zaaktype.referentieproces_naam, 'ReferentieProces 0')
         self.assertEqual(zaaktype.zaaktypenrelaties.get().gerelateerd_zaaktype, 'http://example.com/zaaktype/1')
-        self.assertEqual(zaaktype.draft, True)
+        self.assertEqual(zaaktype.concept, True)
 
-    def test_create_zaaktype_fail_besluittype_non_draft(self):
-        besluittype = BesluitTypeFactory.create(draft=False, catalogus=self.catalogus)
+    def test_create_zaaktype_fail_besluittype_non_concept(self):
+        besluittype = BesluitTypeFactory.create(concept=False, catalogus=self.catalogus)
         besluittype_url = get_operation_url('besluittype_read', uuid=besluittype.uuid)
 
         zaaktype_list_url = get_operation_url('zaaktype_list')
@@ -213,7 +213,7 @@ class ZaakTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], "Relations to a non-draft besluittype_set object can't be created")
+        self.assertEqual(data['detail'], "Relations to a non-concept besluittype_set object can't be created")
 
     def test_create_zaaktype_fail_different_catalogus_besluittypes(self):
         besluittype = BesluitTypeFactory.create()
@@ -271,7 +271,7 @@ class ZaakTypeAPITests(APITestCase):
 
         zaaktype.refresh_from_db()
 
-        self.assertEqual(zaaktype.draft, False)
+        self.assertEqual(zaaktype.concept, False)
 
     def test_delete_zaaktype(self):
         zaaktype = ZaakTypeFactory.create()
@@ -282,8 +282,8 @@ class ZaakTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(ZaakType.objects.filter(id=zaaktype.id))
 
-    def test_delete_zaaktype_fail_not_draft(self):
-        zaaktype = ZaakTypeFactory.create(draft=False)
+    def test_delete_zaaktype_fail_not_concept(self):
+        zaaktype = ZaakTypeFactory.create(concept=False)
         zaaktype_url = get_operation_url('zaaktype_read', uuid=zaaktype.uuid)
 
         response = self.client.delete(zaaktype_url)
@@ -291,15 +291,15 @@ class ZaakTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-draft object is forbidden')
+        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
 
 
 class ZaakTypeFilterAPITests(APITestCase):
     maxDiff = None
 
     def test_filter_zaaktype_publish_all(self):
-        ZaakTypeFactory.create(draft=True)
-        ZaakTypeFactory.create(draft=False)
+        ZaakTypeFactory.create(concept=True)
+        ZaakTypeFactory.create(concept=False)
         zaaktype_list_url = get_operation_url('zaaktype_list')
 
         response = self.client.get(zaaktype_list_url, {'publish': 'all'})
@@ -309,13 +309,13 @@ class ZaakTypeFilterAPITests(APITestCase):
 
         self.assertEqual(len(data), 2)
 
-    def test_filter_zaaktype_publish_draft(self):
-        zaaktype1 = ZaakTypeFactory.create(draft=True)
-        zaaktype2 = ZaakTypeFactory.create(draft=False)
+    def test_filter_zaaktype_publish_concept(self):
+        zaaktype1 = ZaakTypeFactory.create(concept=True)
+        zaaktype2 = ZaakTypeFactory.create(concept=False)
         zaaktype_list_url = get_operation_url('zaaktype_list')
         zaaktype1_url = get_operation_url('zaaktype_read', uuid=zaaktype1.uuid)
 
-        response = self.client.get(zaaktype_list_url, {'publish': 'draft'})
+        response = self.client.get(zaaktype_list_url, {'publish': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -323,13 +323,13 @@ class ZaakTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{zaaktype1_url}')
 
-    def test_filter_zaaktype_publish_nondraft(self):
-        zaaktype1 = ZaakTypeFactory.create(draft=True)
-        zaaktype2 = ZaakTypeFactory.create(draft=False)
+    def test_filter_zaaktype_publish_nonconcept(self):
+        zaaktype1 = ZaakTypeFactory.create(concept=True)
+        zaaktype2 = ZaakTypeFactory.create(concept=False)
         zaaktype_list_url = get_operation_url('zaaktype_list')
         zaaktype2_url = get_operation_url('zaaktype_read', uuid=zaaktype2.uuid)
 
-        response = self.client.get(zaaktype_list_url, {'publish': 'nondraft'})
+        response = self.client.get(zaaktype_list_url, {'publish': 'nonconcept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_zaken.py
+++ b/src/ztc/api/tests/test_zaken.py
@@ -19,9 +19,11 @@ from .base import APITestCase
 class ZaakTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list(self):
-        ZaakTypeFactory.create(catalogus=self.catalogus)
+    def test_get_list_default_nondraft(self):
+        zaaktype1 = ZaakTypeFactory.create(draft=True)
+        zaaktype2 = ZaakTypeFactory.create(draft=False)
         zaaktype_list_url = get_operation_url('zaaktype_list')
+        zaaktype2_url = get_operation_url('zaaktype_read', uuid=zaaktype2.uuid)
 
         response = self.client.get(zaaktype_list_url)
         self.assertEqual(response.status_code, 200)
@@ -29,6 +31,7 @@ class ZaakTypeAPITests(APITestCase):
         data = response.json()
 
         self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['url'], f'http://testserver{zaaktype2_url}')
 
     def test_get_detail(self):
         zaaktype = ZaakTypeFactory.create(catalogus=self.catalogus)

--- a/src/ztc/api/tests/test_zaken.py
+++ b/src/ztc/api/tests/test_zaken.py
@@ -19,7 +19,7 @@ from .base import APITestCase
 class ZaakTypeAPITests(APITestCase):
     maxDiff = None
 
-    def test_get_list_default_nonconcept(self):
+    def test_get_list_default_definitief(self):
         zaaktype1 = ZaakTypeFactory.create(concept=True)
         zaaktype2 = ZaakTypeFactory.create(concept=False)
         zaaktype_list_url = get_operation_url('zaaktype_list')
@@ -297,25 +297,25 @@ class ZaakTypeAPITests(APITestCase):
 class ZaakTypeFilterAPITests(APITestCase):
     maxDiff = None
 
-    def test_filter_zaaktype_publish_all(self):
+    def test_filter_zaaktype_status_alles(self):
         ZaakTypeFactory.create(concept=True)
         ZaakTypeFactory.create(concept=False)
         zaaktype_list_url = get_operation_url('zaaktype_list')
 
-        response = self.client.get(zaaktype_list_url, {'publish': 'all'})
+        response = self.client.get(zaaktype_list_url, {'status': 'alles'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
 
         self.assertEqual(len(data), 2)
 
-    def test_filter_zaaktype_publish_concept(self):
+    def test_filter_zaaktype_status_concept(self):
         zaaktype1 = ZaakTypeFactory.create(concept=True)
         zaaktype2 = ZaakTypeFactory.create(concept=False)
         zaaktype_list_url = get_operation_url('zaaktype_list')
         zaaktype1_url = get_operation_url('zaaktype_read', uuid=zaaktype1.uuid)
 
-        response = self.client.get(zaaktype_list_url, {'publish': 'concept'})
+        response = self.client.get(zaaktype_list_url, {'status': 'concept'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -323,13 +323,13 @@ class ZaakTypeFilterAPITests(APITestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]['url'], f'http://testserver{zaaktype1_url}')
 
-    def test_filter_zaaktype_publish_nonconcept(self):
+    def test_filter_zaaktype_status_definitief(self):
         zaaktype1 = ZaakTypeFactory.create(concept=True)
         zaaktype2 = ZaakTypeFactory.create(concept=False)
         zaaktype_list_url = get_operation_url('zaaktype_list')
         zaaktype2_url = get_operation_url('zaaktype_read', uuid=zaaktype2.uuid)
 
-        response = self.client.get(zaaktype_list_url, {'publish': 'nonconcept'})
+        response = self.client.get(zaaktype_list_url, {'status': 'definitief'})
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/src/ztc/api/tests/test_zaken.py
+++ b/src/ztc/api/tests/test_zaken.py
@@ -291,7 +291,7 @@ class ZaakTypeAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         data = response.json()
-        self.assertEqual(data['detail'], 'Deleting a non-concept object is forbidden')
+        self.assertEqual(data['detail'], 'Alleen concepten kunnen worden verwijderd.')
 
 
 class ZaakTypeFilterAPITests(APITestCase):

--- a/src/ztc/api/views/besluittype.py
+++ b/src/ztc/api/views/besluittype.py
@@ -4,11 +4,11 @@ from ...datamodel.models import BesluitType
 from ..filters import BesluitTypeFilter
 from ..scopes import SCOPE_ZAAKTYPES_READ, SCOPE_ZAAKTYPES_WRITE
 from ..serializers import BesluitTypeSerializer
-from .mixins import DraftMixin, M2MDraftCreateMixin
+from .mixins import ConceptMixin, M2MConceptCreateMixin
 
 
-class BesluitTypeViewSet(DraftMixin,
-                         M2MDraftCreateMixin,
+class BesluitTypeViewSet(ConceptMixin,
+                         M2MConceptCreateMixin,
                          mixins.CreateModelMixin,
                          mixins.DestroyModelMixin,
                          viewsets.ReadOnlyModelViewSet):
@@ -32,4 +32,4 @@ class BesluitTypeViewSet(DraftMixin,
         'destroy': SCOPE_ZAAKTYPES_WRITE,
         'publish': SCOPE_ZAAKTYPES_WRITE,
     }
-    draft_related_fields = ['informatieobjecttypes', 'zaaktypes']
+    concept_related_fields = ['informatieobjecttypes', 'zaaktypes']

--- a/src/ztc/api/views/eigenschap.py
+++ b/src/ztc/api/views/eigenschap.py
@@ -5,10 +5,10 @@ from ztc.datamodel.models import Eigenschap
 from ..filters import EigenschapFilter
 from ..scopes import SCOPE_ZAAKTYPES_READ, SCOPE_ZAAKTYPES_WRITE
 from ..serializers import EigenschapSerializer
-from .mixins import ZaakTypeDraftMixin
+from .mixins import ZaakTypeConceptMixin
 
 
-class EigenschapViewSet(ZaakTypeDraftMixin,
+class EigenschapViewSet(ZaakTypeConceptMixin,
                         mixins.CreateModelMixin,
                         mixins.DestroyModelMixin,
                         viewsets.ReadOnlyModelViewSet):

--- a/src/ztc/api/views/informatieobjecttype.py
+++ b/src/ztc/api/views/informatieobjecttype.py
@@ -4,10 +4,10 @@ from ...datamodel.models import InformatieObjectType
 from ..filters import InformatieObjectTypeFilter
 from ..scopes import SCOPE_ZAAKTYPES_READ, SCOPE_ZAAKTYPES_WRITE
 from ..serializers import InformatieObjectTypeSerializer
-from .mixins import DraftMixin
+from .mixins import ConceptMixin
 
 
-class InformatieObjectTypeViewSet(DraftMixin,
+class InformatieObjectTypeViewSet(ConceptMixin,
                                   mixins.CreateModelMixin,
                                   mixins.DestroyModelMixin,
                                   viewsets.ReadOnlyModelViewSet):

--- a/src/ztc/api/views/mixins.py
+++ b/src/ztc/api/views/mixins.py
@@ -101,5 +101,3 @@ class M2MDraftCreateMixin:
                     raise PermissionDenied(detail=msg)
 
         super().perform_create(serializer)
-
-

--- a/src/ztc/api/views/mixins.py
+++ b/src/ztc/api/views/mixins.py
@@ -27,7 +27,7 @@ class ConceptDestroyMixin:
 
     def perform_destroy(self, instance):
         if not self.get_concept(instance):
-            msg = _("Deleting a non-concept object is forbidden")
+            msg = _("Alleen concepten kunnen worden verwijderd.")
             raise PermissionDenied(detail=msg)
 
         super().perform_destroy(instance)

--- a/src/ztc/api/views/mixins.py
+++ b/src/ztc/api/views/mixins.py
@@ -45,15 +45,15 @@ class ConceptFilterMixin:
 
         # show only non-concepts by default
         query_params = self.request.query_params or {}
-        if 'publish' in query_params:
+        if 'status' in query_params:
             return qs
 
         return qs.filter(**self.get_concept_filter())
 
 
 class ConceptMixin(ConceptPublishMixin,
-                 ConceptDestroyMixin,
-                 ConceptFilterMixin):
+                   ConceptDestroyMixin,
+                   ConceptFilterMixin):
     """ mixin for resources which have 'concept' field"""
     pass
 
@@ -79,8 +79,8 @@ class ZaakTypeConceptFilterMixin(ConceptFilterMixin):
 
 
 class ZaakTypeConceptMixin(ZaakTypeConceptCreateMixin,
-                         ZaakTypeConceptDestroyMixin,
-                         ZaakTypeConceptFilterMixin):
+                           ZaakTypeConceptDestroyMixin,
+                           ZaakTypeConceptFilterMixin):
     """
     mixin for resources which have FK or one-to-one relations with ZaakType objects,
     which support concept functionality

--- a/src/ztc/api/views/relatieklassen.py
+++ b/src/ztc/api/views/relatieklassen.py
@@ -15,10 +15,11 @@ from ..serializers import (
 )
 from ..utils.rest_flex_fields import FlexFieldsMixin
 from ..utils.viewsets import FilterSearchOrderingViewSetMixin
-from .mixins import DraftDestroyMixin
+from .mixins import DraftDestroyMixin, DraftFilterMixin
 
 
-class ZaakTypeInformatieObjectTypeViewSet(DraftDestroyMixin,
+class ZaakTypeInformatieObjectTypeViewSet(DraftFilterMixin,
+                                          DraftDestroyMixin,
                                           mixins.CreateModelMixin,
                                           mixins.DestroyModelMixin,
                                           viewsets.ReadOnlyModelViewSet):
@@ -59,6 +60,9 @@ class ZaakTypeInformatieObjectTypeViewSet(DraftDestroyMixin,
             msg = _("Creating relations between non-draft objects is forbidden")
             raise PermissionDenied(detail=msg)
         super().perform_create(serializer)
+
+    def get_draft_filter(self):
+        return {'zaaktype__draft': False, 'informatie_object_type__draft': False}
 
 
 class ZaakInformatieobjectTypeArchiefregimeViewSet(NestedViewSetMixin, FilterSearchOrderingViewSetMixin,

--- a/src/ztc/api/views/relatieklassen.py
+++ b/src/ztc/api/views/relatieklassen.py
@@ -15,11 +15,11 @@ from ..serializers import (
 )
 from ..utils.rest_flex_fields import FlexFieldsMixin
 from ..utils.viewsets import FilterSearchOrderingViewSetMixin
-from .mixins import DraftDestroyMixin, DraftFilterMixin
+from .mixins import ConceptDestroyMixin, ConceptFilterMixin
 
 
-class ZaakTypeInformatieObjectTypeViewSet(DraftFilterMixin,
-                                          DraftDestroyMixin,
+class ZaakTypeInformatieObjectTypeViewSet(ConceptFilterMixin,
+                                          ConceptDestroyMixin,
                                           mixins.CreateModelMixin,
                                           mixins.DestroyModelMixin,
                                           viewsets.ReadOnlyModelViewSet):
@@ -49,20 +49,20 @@ class ZaakTypeInformatieObjectTypeViewSet(DraftFilterMixin,
         'destroy': SCOPE_ZAAKTYPES_WRITE,
     }
 
-    def get_draft(self, instance):
-        return instance.zaaktype.draft and instance.informatie_object_type.draft
+    def get_concept(self, instance):
+        return instance.zaaktype.concept and instance.informatie_object_type.concept
 
     def perform_create(self, serializer):
         zaaktype = serializer.validated_data['zaaktype']
         informatie_object_type = serializer.validated_data['informatie_object_type']
 
-        if not(zaaktype.draft and informatie_object_type.draft):
-            msg = _("Creating relations between non-draft objects is forbidden")
+        if not(zaaktype.concept and informatie_object_type.concept):
+            msg = _("Creating relations between non-concept objects is forbidden")
             raise PermissionDenied(detail=msg)
         super().perform_create(serializer)
 
-    def get_draft_filter(self):
-        return {'zaaktype__draft': False, 'informatie_object_type__draft': False}
+    def get_concept_filter(self):
+        return {'zaaktype__concept': False, 'informatie_object_type__concept': False}
 
 
 class ZaakInformatieobjectTypeArchiefregimeViewSet(NestedViewSetMixin, FilterSearchOrderingViewSetMixin,

--- a/src/ztc/api/views/resultaattype.py
+++ b/src/ztc/api/views/resultaattype.py
@@ -4,10 +4,10 @@ from ...datamodel.models import ResultaatType
 from ..filters import ResultaatTypeFilter
 from ..scopes import SCOPE_ZAAKTYPES_READ, SCOPE_ZAAKTYPES_WRITE
 from ..serializers import ResultaatTypeSerializer
-from .mixins import ZaakTypeDraftMixin
+from .mixins import ZaakTypeConceptMixin
 
 
-class ResultaatTypeViewSet(ZaakTypeDraftMixin,
+class ResultaatTypeViewSet(ZaakTypeConceptMixin,
                            mixins.CreateModelMixin,
                            mixins.DestroyModelMixin,
                            viewsets.ReadOnlyModelViewSet):

--- a/src/ztc/api/views/roltype.py
+++ b/src/ztc/api/views/roltype.py
@@ -5,11 +5,11 @@ from ...datamodel.models import RolType
 from ..filters import RolTypeFilter
 from ..scopes import SCOPE_ZAAKTYPES_READ, SCOPE_ZAAKTYPES_WRITE
 from ..serializers import RolTypeSerializer
-from .mixins import ZaakTypeDraftMixin
+from .mixins import ZaakTypeConceptMixin
 
 
 class RolTypeViewSet(CheckQueryParamsMixin,
-                     ZaakTypeDraftMixin,
+                     ZaakTypeConceptMixin,
                      mixins.CreateModelMixin,
                      mixins.DestroyModelMixin,
                      viewsets.ReadOnlyModelViewSet):

--- a/src/ztc/api/views/statustype.py
+++ b/src/ztc/api/views/statustype.py
@@ -4,10 +4,10 @@ from ...datamodel.models import StatusType
 from ..filters import StatusTypeFilter
 from ..scopes import SCOPE_ZAAKTYPES_READ, SCOPE_ZAAKTYPES_WRITE
 from ..serializers import StatusTypeSerializer
-from .mixins import ZaakTypeDraftMixin
+from .mixins import ZaakTypeConceptMixin
 
 
-class StatusTypeViewSet(ZaakTypeDraftMixin,
+class StatusTypeViewSet(ZaakTypeConceptMixin,
                         mixins.CreateModelMixin,
                         mixins.DestroyModelMixin,
                         viewsets.ReadOnlyModelViewSet):

--- a/src/ztc/api/views/zaken.py
+++ b/src/ztc/api/views/zaken.py
@@ -7,7 +7,7 @@ from ..scopes import SCOPE_ZAAKTYPES_READ, SCOPE_ZAAKTYPES_WRITE
 from ..serializers import ZaakObjectTypeSerializer, ZaakTypeSerializer
 from ..utils.rest_flex_fields import FlexFieldsMixin
 from ..utils.viewsets import FilterSearchOrderingViewSetMixin
-from .mixins import DraftMixin, M2MDraftCreateMixin
+from .mixins import ConceptMixin, M2MConceptCreateMixin
 
 
 class ZaakObjectTypeViewSet(NestedViewSetMixin, FilterSearchOrderingViewSetMixin,
@@ -29,8 +29,8 @@ class ZaakObjectTypeViewSet(NestedViewSetMixin, FilterSearchOrderingViewSetMixin
     }
 
 
-class ZaakTypeViewSet(DraftMixin,
-                      M2MDraftCreateMixin,
+class ZaakTypeViewSet(ConceptMixin,
+                      M2MConceptCreateMixin,
                       mixins.CreateModelMixin,
                       mixins.DestroyModelMixin,
                       viewsets.ReadOnlyModelViewSet):
@@ -62,4 +62,4 @@ class ZaakTypeViewSet(DraftMixin,
         'destroy': SCOPE_ZAAKTYPES_WRITE,
         'publish': SCOPE_ZAAKTYPES_WRITE,
     }
-    draft_related_fields = ['besluittype_set']
+    concept_related_fields = ['besluittype_set']

--- a/src/ztc/datamodel/admin/besluittype.py
+++ b/src/ztc/datamodel/admin/besluittype.py
@@ -2,11 +2,11 @@ from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
 
 from ..models import BesluitType
-from .mixins import DraftAdminMixin, GeldigheidAdminMixin
+from .mixins import ConceptAdminMixin, GeldigheidAdminMixin
 
 
 @admin.register(BesluitType)
-class BesluitTypeAdmin(GeldigheidAdminMixin, DraftAdminMixin, admin.ModelAdmin):
+class BesluitTypeAdmin(GeldigheidAdminMixin, ConceptAdminMixin, admin.ModelAdmin):
     # List
     list_display = ('catalogus', 'omschrijving', 'besluitcategorie', )
 

--- a/src/ztc/datamodel/admin/informatieobjecttype.py
+++ b/src/ztc/datamodel/admin/informatieobjecttype.py
@@ -5,7 +5,7 @@ from ..models import (
     InformatieObjectType, InformatieObjectTypeOmschrijvingGeneriek,
     ZaakInformatieobjectType
 )
-from .mixins import DraftAdminMixin, GeldigheidAdminMixin
+from .mixins import ConceptAdminMixin, GeldigheidAdminMixin
 
 
 class ZaakInformatieobjectTypeInline(admin.TabularInline):
@@ -41,7 +41,7 @@ class InformatieObjectTypeOmschrijvingGeneriekAdmin(GeldigheidAdminMixin, admin.
 
 
 @admin.register(InformatieObjectType)
-class InformatieObjectTypeAdmin(GeldigheidAdminMixin, DraftAdminMixin, admin.ModelAdmin):
+class InformatieObjectTypeAdmin(GeldigheidAdminMixin, ConceptAdminMixin, admin.ModelAdmin):
     list_display = ('catalogus', 'omschrijving', 'informatieobjectcategorie', )
     list_filter = ('catalogus', 'informatieobjectcategorie')
     search_fields = ('omschrijving', 'informatieobjectcategorie', 'trefwoord', 'toelichting')

--- a/src/ztc/datamodel/admin/mixins.py
+++ b/src/ztc/datamodel/admin/mixins.py
@@ -46,11 +46,11 @@ class FilterSearchOrderingAdminMixin(object):
         return self.get_model_option('search_fields', super().get_search_fields(request))
 
 
-class DraftAdminMixin(object):
+class ConceptAdminMixin(object):
     def get_fieldsets(self, request, obj=None):
         fieldsets = super().get_fieldsets(request, obj)
         return tuple(fieldsets) + (
-            (_('Draft'), {
-                'fields': ('draft', )
+            (_('Concept'), {
+                'fields': ('concept', )
             }),
         )

--- a/src/ztc/datamodel/admin/zaken.py
+++ b/src/ztc/datamodel/admin/zaken.py
@@ -10,7 +10,7 @@ from ..models import (
 from .eigenschap import EigenschapAdmin
 from .forms import ZaakTypeForm
 from .mixins import (
-    DraftAdminMixin, FilterSearchOrderingAdminMixin, GeldigheidAdminMixin
+    ConceptAdminMixin, FilterSearchOrderingAdminMixin, GeldigheidAdminMixin
 )
 from .resultaattype import ResultaatTypeAdmin
 from .roltype import RolTypeAdmin
@@ -79,7 +79,7 @@ class ZaakTypenRelatieInline(admin.TabularInline):
 
 @admin.register(ZaakType)
 class ZaakTypeAdmin(ListObjectActionsAdminMixin, FilterSearchOrderingAdminMixin,
-                    GeldigheidAdminMixin, DraftAdminMixin, admin.ModelAdmin):
+                    GeldigheidAdminMixin, ConceptAdminMixin, admin.ModelAdmin):
     model = ZaakType
     form = ZaakTypeForm
 

--- a/src/ztc/datamodel/migrations/0100_auto_20190621_1021.py
+++ b/src/ztc/datamodel/migrations/0100_auto_20190621_1021.py
@@ -12,17 +12,23 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
             model_name='besluittype',
-            name='draft',
-            field=models.BooleanField(default=True, help_text='Flag indicating the object is a draft', verbose_name='draft'),
+            name='concept',
+            field=models.BooleanField(default=True,
+                                      help_text='Geeft aan of het object een concept betreft. Concepten zijn niet-definitieve versies en zouden niet gebruikt moeten worden buiten deze API.',
+                                      verbose_name='concept'),
         ),
         migrations.AddField(
             model_name='informatieobjecttype',
-            name='draft',
-            field=models.BooleanField(default=True, help_text='Flag indicating the object is a draft', verbose_name='draft'),
+            name='concept',
+            field=models.BooleanField(default=True,
+                                      help_text='Geeft aan of het object een concept betreft. Concepten zijn niet-definitieve versies en zouden niet gebruikt moeten worden buiten deze API.',
+                                      verbose_name='concept'),
         ),
         migrations.AddField(
             model_name='zaaktype',
-            name='draft',
-            field=models.BooleanField(default=True, help_text='Flag indicating the object is a draft', verbose_name='draft'),
+            name='concept',
+            field=models.BooleanField(default=True,
+                                      help_text='Geeft aan of het object een concept betreft. Concepten zijn niet-definitieve versies en zouden niet gebruikt moeten worden buiten deze API.',
+                                      verbose_name='concept'),
         ),
     ]

--- a/src/ztc/datamodel/migrations/0101_update_concept.py
+++ b/src/ztc/datamodel/migrations/0101_update_concept.py
@@ -3,14 +3,14 @@
 from django.db import migrations
 
 
-def update_draft(apps, schema_editor):
+def update_concept(apps, schema_editor):
     ZaakType = apps.get_model('datamodel.ZaakType')
     BesluitType = apps.get_model('datamodel.BesluitType')
     InformatieObjectType = apps.get_model('datamodel.InformatieObjectType')
 
     for model in [ZaakType, BesluitType, InformatieObjectType]:
         for model_object in model.objects.all():
-            model_object.draft = False
+            model_object.concept = False
             model_object.save()
 
 
@@ -21,5 +21,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(update_draft),
+        migrations.RunPython(update_concept),
     ]

--- a/src/ztc/datamodel/models/besluittype.py
+++ b/src/ztc/datamodel/models/besluittype.py
@@ -5,10 +5,10 @@ from django.utils.translation import ugettext_lazy as _
 
 from vng_api_common.fields import DaysDurationField
 
-from .mixins import DraftMixin, GeldigheidMixin
+from .mixins import ConceptMixin, GeldigheidMixin
 
 
-class BesluitType(GeldigheidMixin,DraftMixin, models.Model):
+class BesluitType(GeldigheidMixin, ConceptMixin, models.Model):
     """
     Generieke aanduiding van de aard van een besluit.
 

--- a/src/ztc/datamodel/models/informatieobjecttype.py
+++ b/src/ztc/datamodel/models/informatieobjecttype.py
@@ -6,7 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from vng_api_common.fields import VertrouwelijkheidsAanduidingField
 
-from .mixins import DraftMixin, GeldigheidMixin
+from .mixins import ConceptMixin, GeldigheidMixin
 
 
 class InformatieObjectTypeOmschrijvingGeneriek(GeldigheidMixin, models.Model):
@@ -56,7 +56,7 @@ class InformatieObjectTypeOmschrijvingGeneriek(GeldigheidMixin, models.Model):
         super().clean()
 
 
-class InformatieObjectType(GeldigheidMixin, DraftMixin, models.Model):
+class InformatieObjectType(GeldigheidMixin, ConceptMixin, models.Model):
     """
     Aanduiding van de aard van INFORMATIEOBJECTen zoals gehanteerd door de zaakbehandelende organisatie.
 

--- a/src/ztc/datamodel/models/mixins.py
+++ b/src/ztc/datamodel/models/mixins.py
@@ -73,9 +73,11 @@ class GeldigheidMixin(models.Model):
                 )
 
 
-class DraftMixin(models.Model):
-    draft = models.BooleanField(
-        _('draft'), default=True, help_text=_('Flag indicating the object is a draft')
+class ConceptMixin(models.Model):
+    concept = models.BooleanField(
+        _('concept'), default=True,
+        help_text=_('Geeft aan of het object een concept betreft. Concepten zijn niet-definitieve '
+                    'versies en zouden niet gebruikt moeten worden buiten deze API.')
     )
 
     class Meta:

--- a/src/ztc/datamodel/models/zaken.py
+++ b/src/ztc/datamodel/models/zaken.py
@@ -14,7 +14,7 @@ from vng_api_common.fields import (
 from vng_api_common.models import APIMixin
 
 from ..choices import InternExtern, JaNee, ObjectTypen
-from .mixins import DraftMixin, GeldigheidMixin
+from .mixins import ConceptMixin, GeldigheidMixin
 
 
 class ZaakObjectType(GeldigheidMixin, models.Model):
@@ -195,7 +195,7 @@ class BronZaakType(models.Model):
         verbose_name_plural = _('Bron zaaktypen')
 
 
-class ZaakType(APIMixin, DraftMixin, GeldigheidMixin, models.Model):
+class ZaakType(APIMixin, ConceptMixin, GeldigheidMixin, models.Model):
     """
     Het geheel van karakteristieke eigenschappen van zaken van eenzelfde soort
 

--- a/src/ztc/datamodel/tests/test_resultaattype_validation.py
+++ b/src/ztc/datamodel/tests/test_resultaattype_validation.py
@@ -330,7 +330,7 @@ class ResultaattypeAfleidingswijzeAndParameterFieldsValidationTests(TestCase):
 
             # parameter fields - no values allowed!
             'brondatum_archiefprocedure_datumkenmerk': 'foo',
-            'brondatum_archiefprocedure_objecttype': 'VerblijfsObject',
+            'brondatum_archiefprocedure_objecttype': 'adres',
             'brondatum_archiefprocedure_registratie': 'ORC',
             'brondatum_archiefprocedure_procestermijn': 'P30D',
         }
@@ -505,7 +505,7 @@ class ResultaattypeAfleidingswijzeAndParameterFieldsValidationTests(TestCase):
 
         form = self._get_form(Afleidingswijze.eigenschap, zaaktype, resultaat_url, **{
             'brondatum_archiefprocedure_datumkenmerk': '',
-            'brondatum_archiefprocedure_objecttype': 'VerblijfsObject',
+            'brondatum_archiefprocedure_objecttype': 'adres',
             'brondatum_archiefprocedure_registratie': 'BRC',
         })
 

--- a/src/ztc/tests/test_userstory_169.py
+++ b/src/ztc/tests/test_userstory_169.py
@@ -45,7 +45,7 @@ class US169TestCase(TypeCheckMixin, ClientAPITestMixin, APITestCase):
         Zie https://github.com/VNG-Realisatie/gemma-zaken/issues/182#issuecomment-408899919
         voor context
         """
-        zaaktype = ZaakTypeFactory.create(draft=False)
+        zaaktype = ZaakTypeFactory.create(concept=False)
         roltype_behandelaar = RolTypeFactory.create(
             zaaktype=zaaktype,
             omschrijving_generiek=RolOmschrijving.behandelaar,

--- a/src/ztc/tests/test_userstory_169.py
+++ b/src/ztc/tests/test_userstory_169.py
@@ -45,7 +45,7 @@ class US169TestCase(TypeCheckMixin, ClientAPITestMixin, APITestCase):
         Zie https://github.com/VNG-Realisatie/gemma-zaken/issues/182#issuecomment-408899919
         voor context
         """
-        zaaktype = ZaakTypeFactory.create()
+        zaaktype = ZaakTypeFactory.create(draft=False)
         roltype_behandelaar = RolTypeFactory.create(
             zaaktype=zaaktype,
             omschrijving_generiek=RolOmschrijving.behandelaar,

--- a/src/ztc/tests/test_userstory_52.py
+++ b/src/ztc/tests/test_userstory_52.py
@@ -16,7 +16,7 @@ from ztc.datamodel.tests.factories import (
 class US52TestCase(TypeCheckMixin, ClientAPITestMixin, APITestCase):
 
     def test_list_eigenschappen(self):
-        zaaktype = ZaakTypeFactory.create(draft=False)
+        zaaktype = ZaakTypeFactory.create(concept=False)
 
         eigenschap1 = EigenschapFactory.create(
             eigenschapnaam='objecttype',

--- a/src/ztc/tests/test_userstory_52.py
+++ b/src/ztc/tests/test_userstory_52.py
@@ -16,7 +16,7 @@ from ztc.datamodel.tests.factories import (
 class US52TestCase(TypeCheckMixin, ClientAPITestMixin, APITestCase):
 
     def test_list_eigenschappen(self):
-        zaaktype = ZaakTypeFactory.create()
+        zaaktype = ZaakTypeFactory.create(draft=False)
 
         eigenschap1 = EigenschapFactory.create(
             eigenschapnaam='objecttype',


### PR DESCRIPTION
Based on https://github.com/VNG-Realisatie/gemma-zaaktypecatalogus/pull/47
Dependent on https://github.com/VNG-Realisatie/vng-api-common/pull/68

**Changes:**
1. Add `publish` filter to all resources which can be draft or draft-related 
1. Add mixins to show only non-draft object by default
1. Update schema with new custom filters
1. Write tests