### PR TITLE
Fix dump data fixture view

### DIFF
--- a/src/ztc/tests/test_dumpdata_fixture_view.py
+++ b/src/ztc/tests/test_dumpdata_fixture_view.py
@@ -1,0 +1,13 @@
+import json
+from django.test import TestCase
+from django.urls import reverse
+
+class DumpDataFixtureViewTests(TestCase):
+    def test_dumpdata_fixture(self):
+        url = reverse('dumpdata-fixture')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.content)
+        self.assertIsNotNone(data)

--- a/src/ztc/views.py
+++ b/src/ztc/views.py
@@ -22,5 +22,5 @@ class DumpDataFixtureView(View):
     def get(self, request):
         response = HttpResponse(content_type='application/json')
         response['Content-Disposition'] = 'attachment; filename="fixture.json"'
-        call_command('dumpdata', args=['datamodel'], indent=4, stdout=response)
+        call_command('dumpdata', 'datamodel', indent=4, stdout=response)
         return response


### PR DESCRIPTION
Currently the dump data fixture view throws a 500 error. This PR adds a testcase and also fixes the problem.

```
ValueError at /data/fixture/
min() arg is an empty sequence
Request Method: | GET
-- | --
2.2.3
ValueError
min() arg is an empty sequence
/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py in <listcomp>, line 125
```
