### PR TITLE
Eigenschap specificatie lengte validatie inconsistent

### DIFF
--- a/src/ztc/api/serializers/eigenschap.py
+++ b/src/ztc/api/serializers/eigenschap.py
@@ -33,6 +33,11 @@ class EigenschapSpecificatieSerializer(serializers.ModelSerializer):
         value_display_mapping = add_choice_values_help_text(FormaatChoices)
         self.fields["formaat"].help_text += f"\n\n{value_display_mapping}"
 
+    def validate(self, attrs):
+        instance = EigenschapSpecificatie(**attrs)
+        instance.clean()
+        return attrs
+
 
 class EigenschapSerializer(serializers.HyperlinkedModelSerializer):
 

--- a/src/ztc/datamodel/models/eigenschap.py
+++ b/src/ztc/datamodel/models/eigenschap.py
@@ -93,8 +93,8 @@ class EigenschapSpecificatie(models.Model):
                 )
 
         elif self.formaat == FormaatChoices.getal:
-            try:  # specificatie spreekt over kommagescheiden decimaal, wij nemen echter aan dat het punt gescheiden is
-                Decimal(self.lengte)
+            try:
+                Decimal(self.lengte.replace(",", "."))
             except (InvalidOperation, TypeError):
                 raise ValidationError(
                     _(


### PR DESCRIPTION
Referenced in open-zaak issue #685 (https://github.com/open-zaak/open-zaak/issues/685):
Eigenschap specificatie validation was inconsistent (expecting a dot-separated number for the `lengte` while asking for a comma-separated number).