### PR TITLE
feature: zaakobjecttype to resultaattype.py and statustype.py as read…

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -12559,6 +12559,19 @@ components:
           description: Omschrijving van de aard van informatieobjecten van dit INFORMATIEOBJECTTYPE.
           title: informatieobjecttypen
           uniqueItems: true
+        zaakobjecttypen:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+          readOnly: true
+          description:
+            De ZAAKOBJECTTYPEn die verplicht gerelateerd moeten zijn aan
+            ZAAKen van dit ZAAKTYPE voordat een resultaat van dit RESULTAATTYPE kan
+            worden gezet.
+          title: Zaakobjecttypen
+          uniqueItems: true
     PatchedRolType:
       type: object
       description: Adds nested create feature
@@ -12771,6 +12784,11 @@ components:
           nullable: true
           description: De datum van de aller laatste versie van het object.
           title: datum einde object
+        zaakobjecttype:
+          type: string
+          format: uri
+          readOnly: true
+          title: Zaakobjecttypen
     PatchedZaakObjectType:
       type: object
       properties:
@@ -12847,8 +12865,8 @@ components:
           items:
             type: string
             format: uri
+            nullable: true
             title: ''
-          readOnly: true
           description: URL-referenties naar de RESULTAATTYPEN.
           title: Zaakobjecttypen
           uniqueItems: true
@@ -12857,8 +12875,8 @@ components:
           items:
             type: string
             format: uri
+            nullable: true
             title: ''
-          readOnly: true
           description: URL-referenties naar de STATUSTYPEN.
           title: Zaakobjecttypen
           uniqueItems: true
@@ -13161,6 +13179,19 @@ components:
           description: Omschrijving van de aard van informatieobjecten van dit INFORMATIEOBJECTTYPE.
           title: informatieobjecttypen
           uniqueItems: true
+        zaakobjecttypen:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+          readOnly: true
+          description:
+            De ZAAKOBJECTTYPEn die verplicht gerelateerd moeten zijn aan
+            ZAAKen van dit ZAAKTYPE voordat een resultaat van dit RESULTAATTYPE kan
+            worden gezet.
+          title: Zaakobjecttypen
+          uniqueItems: true
       required:
         - besluittypeOmschrijving
         - informatieobjecttypeOmschrijving
@@ -13169,6 +13200,7 @@ components:
         - resultaattypeomschrijving
         - selectielijstklasse
         - url
+        - zaakobjecttypen
         - zaaktype
         - zaaktypeIdentificatie
     ResultaatTypeCreate:
@@ -13372,6 +13404,19 @@ components:
           description: Omschrijving van de aard van informatieobjecten van dit INFORMATIEOBJECTTYPE.
           title: informatieobjecttypen
           uniqueItems: true
+        zaakobjecttypen:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+          readOnly: true
+          description:
+            De ZAAKOBJECTTYPEn die verplicht gerelateerd moeten zijn aan
+            ZAAKen van dit ZAAKTYPE voordat een resultaat van dit RESULTAATTYPE kan
+            worden gezet.
+          title: Zaakobjecttypen
+          uniqueItems: true
       required:
         - besluittypeOmschrijving
         - besluittypen
@@ -13381,6 +13426,7 @@ components:
         - resultaattypeomschrijving
         - selectielijstklasse
         - url
+        - zaakobjecttypen
         - zaaktype
         - zaaktypeIdentificatie
     ResultaatTypeUpdate:
@@ -13584,6 +13630,19 @@ components:
           description: Omschrijving van de aard van informatieobjecten van dit INFORMATIEOBJECTTYPE.
           title: informatieobjecttypen
           uniqueItems: true
+        zaakobjecttypen:
+          type: array
+          items:
+            type: string
+            format: uri
+            title: ''
+          readOnly: true
+          description:
+            De ZAAKOBJECTTYPEn die verplicht gerelateerd moeten zijn aan
+            ZAAKen van dit ZAAKTYPE voordat een resultaat van dit RESULTAATTYPE kan
+            worden gezet.
+          title: Zaakobjecttypen
+          uniqueItems: true
       required:
         - besluittypeOmschrijving
         - besluittypen
@@ -13593,6 +13652,7 @@ components:
         - resultaattypeomschrijving
         - selectielijstklasse
         - url
+        - zaakobjecttypen
         - zaaktype
         - zaaktypeIdentificatie
     RichtingEnum:
@@ -13819,12 +13879,18 @@ components:
           nullable: true
           description: De datum van de aller laatste versie van het object.
           title: datum einde object
+        zaakobjecttype:
+          type: string
+          format: uri
+          readOnly: true
+          title: Zaakobjecttypen
       required:
         - catalogus
         - isEindstatus
         - omschrijving
         - url
         - volgnummer
+        - zaakobjecttype
         - zaaktype
         - zaaktypeIdentificatie
     ValidatieFout:
@@ -13956,8 +14022,8 @@ components:
           items:
             type: string
             format: uri
+            nullable: true
             title: ''
-          readOnly: true
           description: URL-referenties naar de RESULTAATTYPEN.
           title: Zaakobjecttypen
           uniqueItems: true
@@ -13966,8 +14032,8 @@ components:
           items:
             type: string
             format: uri
+            nullable: true
             title: ''
-          readOnly: true
           description: URL-referenties naar de STATUSTYPEN.
           title: Zaakobjecttypen
           uniqueItems: true
@@ -13984,8 +14050,6 @@ components:
         - catalogus
         - objecttype
         - relatieOmschrijving
-        - resultaattypen
-        - statustypen
         - url
         - zaaktype
         - zaaktypeIdentificatie

--- a/src/resources.md
+++ b/src/resources.md
@@ -178,6 +178,7 @@ Uitleg bij mogelijke waarden:
 | besluittypeOmschrijving | Omschrijving van de aard van BESLUITen van het BESLUITTYPE. | array | ja | ~~C~~​R​~~U~~​~~D~~ |
 | informatieobjecttypen | De INFORMATIEOBJECTTYPEn die verplicht aanwezig moeten zijn in het zaakdossier van ZAAKen van dit ZAAKTYPE voordat een resultaat van dit RESULTAATTYPE kan worden gezet. | array | nee | C​R​U​D |
 | informatieobjecttypeOmschrijving | Omschrijving van de aard van informatieobjecten van dit INFORMATIEOBJECTTYPE. | array | ja | ~~C~~​R​~~U~~​~~D~~ |
+| zaakobjecttypen | De ZAAKOBJECTTYPEn die verplicht gerelateerd moeten zijn aan ZAAKen van dit ZAAKTYPE voordat een resultaat van dit RESULTAATTYPE kan worden gezet. | array | ja | ~~C~~​R​~~U~~​~~D~~ |
 
 ## RolType
 
@@ -231,6 +232,7 @@ Objecttype op [GEMMA Online](https://www.gemmaonline.nl/index.php/Imztc_2.1/doc/
 | eindeGeldigheid | De datum waarop het is opgeheven. | string | nee | C​R​U​D |
 | beginObject | De datum waarop de eerst versie van het object ontstaan is. | string | nee | C​R​U​D |
 | eindeObject | De datum van de aller laatste versie van het object. | string | nee | C​R​U​D |
+| zaakobjecttype |  | string | ja | ~~C~~​R​~~U~~​~~D~~ |
 
 ## ZaakObjectType
 
@@ -248,8 +250,8 @@ Objecttype op [GEMMA Online](https://www.gemmaonline.nl/index.php/Imztc_2.1/doc/
 | relatieOmschrijving | Omschrijving van de betrekking van het Objecttype op zaken van het gerelateerde ZAAKTYPE. | string | ja | C​R​U​D |
 | zaaktype | URL-referentie naar de ZAAKTYPE waartoe dit ZAAKOBJECTTYPE behoort. | string | ja | C​R​U​D |
 | zaaktypeIdentificatie | Unieke identificatie van het ZAAKTYPE binnen de CATALOGUS waarin het ZAAKTYPE voorkomt. | string | ja | ~~C~~​R​~~U~~​~~D~~ |
-| resultaattypen | URL-referenties naar de RESULTAATTYPEN. | array | ja | ~~C~~​R​~~U~~​~~D~~ |
-| statustypen | URL-referenties naar de STATUSTYPEN. | array | ja | ~~C~~​R​~~U~~​~~D~~ |
+| resultaattypen | URL-referenties naar de RESULTAATTYPEN. | array | nee | C​R​U​D |
+| statustypen | URL-referenties naar de STATUSTYPEN. | array | nee | C​R​U​D |
 | catalogus | URL-referentie naar de CATALOGUS waartoe dit ZAAKOBJECTTYPE behoort. | string | ja | C​R​U​D |
 
 ## ZaakType

--- a/src/ztc/api/serializers/resultaattype.py
+++ b/src/ztc/api/serializers/resultaattype.py
@@ -108,6 +108,7 @@ class ResultaatTypeSerializer(
             "besluittype_omschrijving",
             "informatieobjecttypen",
             "informatieobjecttype_omschrijving",
+            "zaakobjecttypen",
         )
         extra_kwargs = {
             "url": {"lookup_field": "uuid"},
@@ -125,6 +126,7 @@ class ResultaatTypeSerializer(
                     "Waarde van de omschrijving-generiek referentie (attribuut `omschrijving`)"
                 ),
             },
+            "zaakobjecttypen": {"lookup_field": "uuid", "read_only": True},
             "zaaktype": {"lookup_field": "uuid", "label": _("is van")},
             "selectielijstklasse": {
                 "validators": [

--- a/src/ztc/api/serializers/statustype.py
+++ b/src/ztc/api/serializers/statustype.py
@@ -68,6 +68,7 @@ class StatusTypeSerializer(serializers.HyperlinkedModelSerializer):
             "einde_geldigheid",
             "begin_object",
             "einde_object",
+            "zaakobjecttype",
         )
         extra_kwargs = {
             "url": {"lookup_field": "uuid"},
@@ -75,6 +76,7 @@ class StatusTypeSerializer(serializers.HyperlinkedModelSerializer):
             "omschrijving_generiek": {"source": "statustype_omschrijving_generiek"},
             "volgnummer": {"source": "statustypevolgnummer"},
             "zaaktype": {"lookup_field": "uuid"},
+            "zaakobjecttype": {"lookup_field": "uuid", "read_only": True},
             "eigenschappen": {"lookup_field": "uuid"},
             "begin_geldigheid": {"source": "datum_begin_geldigheid"},
             "einde_geldigheid": {"source": "datum_einde_geldigheid"},

--- a/src/ztc/api/serializers/zaakobjecttype.py
+++ b/src/ztc/api/serializers/zaakobjecttype.py
@@ -40,13 +40,13 @@ class ZaakObjectTypeSerializer(HyperlinkedModelSerializer):
             "zaaktype": {"lookup_field": "uuid"},
             "resultaattypen": {
                 "lookup_field": "uuid",
-                "read_only": True,
                 "help_text": _("URL-referenties naar de RESULTAATTYPEN."),
+                "required": False,
             },
             "statustypen": {
                 "lookup_field": "uuid",
-                "read_only": True,
                 "help_text": _("URL-referenties naar de STATUSTYPEN."),
+                "required": False,
             },
             "catalogus": {"lookup_field": "uuid"},
             "begin_geldigheid": {"source": "datum_begin_geldigheid"},

--- a/src/ztc/api/tests/test_resultaattype.py
+++ b/src/ztc/api/tests/test_resultaattype.py
@@ -166,6 +166,7 @@ class ResultaatTypeAPITests(TypeCheckMixin, APITestCase):
                     "registratie": "",
                     "procestermijn": None,
                 },
+                "zaakobjecttypen": [],
                 "procesobjectaard": "proces aard",
                 "catalogus": f"http://testserver{catalogus_url}",
                 "beginGeldigheid": "2021-10-30",

--- a/src/ztc/api/tests/test_statustype.py
+++ b/src/ztc/api/tests/test_statustype.py
@@ -100,6 +100,7 @@ class StatusTypeAPITests(APITestCase):
             "eindeObject": None,
             "zaaktypeIdentificatie": zaaktype.identificatie,
             "catalogus": f"http://testserver{reverse(self.catalogus)}",
+            "zaakobjecttype": None,
         }
 
         self.assertEqual(expected, response.json())


### PR DESCRIPTION
…_only. Inside zaakobjecttype, resultaattype and statustype POSTable, not required.